### PR TITLE
slug_trade_app removed from all routes

### DIFF
--- a/slug_trade/slug_trade/settings.py
+++ b/slug_trade/slug_trade/settings.py
@@ -131,4 +131,4 @@ STATICFILES_DIRS = [
     STATIC_DIR,
 ]
 
-LOGIN_REDIRECT_URL = '/slug_trade_app/home/'
+LOGIN_REDIRECT_URL = '/home/'

--- a/slug_trade/slug_trade/urls.py
+++ b/slug_trade/slug_trade/urls.py
@@ -22,5 +22,5 @@ from django.conf.urls.static import static
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^admin/', admin.site.urls),
-    url(r'^slug_trade_app/', include('slug_trade_app.urls')),
+    url('', include('slug_trade_app.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -11,8 +11,6 @@ def index(request):
 def products(request):
     return render(request, 'slug_trade_app/products.html')
 
-
-
 def profile(request):
 
     if request.user.is_authenticated():

--- a/slug_trade/templates/slug_trade_app/base.html
+++ b/slug_trade/templates/slug_trade_app/base.html
@@ -11,12 +11,12 @@
 
   <body>
     <h1>BASE</h1>
-    {% if request.path != "/slug_trade_app/login/" %}
+    {% if request.path != "/login/" %}
       {% if user.is_authenticated %}
         <p>Welcome, {{ user.get_username }}. Thanks for logging in.</p>
-        <p>You can logout <a href="/slug_trade_app/logout/">here</a></p>
+        <p>You can logout <a href="/logout/">here</a></p>
       {% else %}
-        <p>Welcome, new user. Please log in <a href="/slug_trade_app/login/">here</a>.</p>
+        <p>Welcome, new user. Please log in <a href="/login/">here</a>.</p>
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
Description:
Removed the slug_trade_app route from all routes so app name will no longer show up in url

Testing:
- Click all links to make sure they are working
- Login and logout
- Go directly to these routes in url:
     http://127.0.0.1:8000/home
     http://127.0.0.1:8000/products
     http://127.0.0.1:8000/profile
     http://127.0.0.1:8000/login