### PR TITLE
Bug Fix: Edit Profile 404 error when user not logged in

### DIFF
--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -81,17 +81,20 @@ def edit_profile(request):
             user_profile_instance.save()
         return redirect('/profile')
     else:
-        user = User.objects.get(id=request.user.id)
-        user_form = UserModelForm(instance=user)
-        user_profile = user.userprofile
-        user_profile_form = UserProfileForm(instance=user_profile)
-        profile_picture_form = ProfilePictureForm()
-        return render(request, 'slug_trade_app/edit_profile.html', {
-            'user_form': user_form, 
-            'user_profile_form': user_profile_form, 
-            'profile_picture_form': profile_picture_form,
-            'user': request.user
-            })
+        if request.user.is_authenticated():
+            user = User.objects.get(id=request.user.id)
+            user_form = UserModelForm(instance=user)
+            user_profile = user.userprofile
+            user_profile_form = UserProfileForm(instance=user_profile)
+            profile_picture_form = ProfilePictureForm()
+            return render(request, 'slug_trade_app/edit_profile.html', {
+                'user_form': user_form, 
+                'user_profile_form': user_profile_form, 
+                'profile_picture_form': profile_picture_form,
+                'user': request.user
+                })
+        else:
+            return render(request, 'slug_trade_app/not_authenticated.html')
 
 def add_closet_item(request):
     if request.method == 'POST':


### PR DESCRIPTION
Problem:
- When the user wasn't logged in, and they tried to go to the edit profile page, it threw a 404 error

How to test:
- Make sure you aren't logged in, then go to /edit_profile/. Make sure that you see the error page rather than a 404 error. 
- Log in and make sure you get directed to the correct page