### PR TITLE
Fixed script to set up virtualenv in repo

### DIFF
--- a/slug_trade/venv_setup.sh
+++ b/slug_trade/venv_setup.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
 python3 -m virtualenv env
-
-pip install -r requirements.txt
-sleep 1
 source env/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
New functionality:

- The script venv_setup.sh now correctly installs the required modules the app.

How to test:

- Ensure that you have python3, pip, and virtualenv installed.
- In the directory slutrade/slug_trade, run the script venv_setup.sh
- Verify that there are no error messages in the script output and that the last line of output begins with "Successfully installed".
- Run the script renew_db.sh and verify that there are no errors in the output.
- Start the script start.sh and verify that the app starts.

Note: If your global python environment already has all the correct modules installed, you will not be able to verify that the virtual environment is set up correctly.