### PR TITLE
bugfix for Issue #35: populate_db creates irregularities in the database

### DIFF
--- a/slug_trade/slug_trade_app/management/commands/populate_db.py
+++ b/slug_trade/slug_trade_app/management/commands/populate_db.py
@@ -67,6 +67,7 @@ class Command(BaseCommand):
         user.is_staff = True
         user.first_name = 'admin'
         user.last_name = 'istrator'
+        user.email = 'admin@slugtrade.com'
         user.save()
 
         profile = models.UserProfile(user=user)
@@ -97,12 +98,13 @@ class Command(BaseCommand):
         location = 'on'
 
         username = name.replace(' ', '')
-        user = User.objects.create_user(username=username.lower(), password='pass1234')
+        email = (username + '@somewhere.com').lower()
+        user = User.objects.create_user(username=email, password='pass1234')
         user.is_superuser = False
         user.is_staff = False
         user.first_name = name.split(' ')[0]
         user.last_name = name.split(' ')[1]
-        user.email = (username + '@somewhere.com').lower()
+        user.email = email
         user.save()
 
         profile = models.UserProfile(user=user)
@@ -132,12 +134,13 @@ class Command(BaseCommand):
 
         for name, bio, location, counter in profile_data:
             username = name.replace(' ', '')
-            user = User.objects.create_user(username=username.lower(), password='pass1234')
+            email = (username + '@somewhere.com').lower()
+            user = User.objects.create_user(username=email, password='pass1234')
             user.is_superuser = False
             user.is_staff = False
             user.first_name = name.split(' ')[0]
             user.last_name = name.split(' ')[1]
-            user.email = (username + '@somewhere.com').lower()
+            user.email = email
             user.save()
 
             profile = models.UserProfile(user=user)


### PR DESCRIPTION
Fixes:

- when populate_db is run, admin now gets an email address
- when populate_db is run, usernames are now set to the full email address

How to test:
- run renew_db.sh
- in the app, go to the endpoint "admin/"
- log in as admin (username: "admin", password: "pass1234")
- view the Users database and verify that the user "admin" has the email "admin@slugtrade.com"
- view the Users database and verify that all the regular users have email addresses for usernames