### PR TITLE
bugfix: navbar name

### DIFF
--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -124,7 +124,7 @@ def public_profile_inspect(request, user_id):
     wishlist = Wishlist.objects.filter(user=User.objects.get(id=user_id))
 
     return render(request, 'slug_trade_app/profile.html', {
-                      'user': user_to_view,
+                      'user_to_view': user_to_view,
                       'public': True,
                       'item_data': items_and_images,
                       'wishlist': wishlist,
@@ -162,7 +162,7 @@ def profile(request):
         items_and_images = zip(items,images)
 
         return render(request, 'slug_trade_app/profile.html', {
-                    'user': request.user,
+                    'user_to_view': request.user,
                     'public': False,
                     'item_data': items_and_images,
                     'wishlist': wishlist,

--- a/slug_trade/templates/slug_trade_app/profile.html
+++ b/slug_trade/templates/slug_trade_app/profile.html
@@ -8,20 +8,20 @@
 <title>Products</title>
 
 {% block body_block %}
-<h1>{{user.first_name}}'s Profile</h1>
+<h1>{{user_to_view.first_name}}'s Profile</h1>
 <p>Welcome back!</p>
 
-{% if user.userprofile.profile_picture %}
+{% if user_to_view.userprofile.profile_picture %}
 <h4>Current Photo:</h4>
 <p>
 <!--URL is: {{ user.userprofile.profile_picture.url }}-->
-</p><img src="{{user.userprofile.profile_picture.url}}" width="240">
+</p><img src="{{user_to_view.userprofile.profile_picture.url}}" width="240">
 {% endif %}
 
-<p>It looks like you live {{user.userprofile.on_off_campus}} campus</p>
+<p>It looks like you live {{user_to_view.userprofile.on_off_campus}} campus</p>
 
 <h4>This is your public bio:</h4>
-<p>{{user.userprofile.bio}}</p><br><br>
+<p>{{user_to_view.userprofile.bio}}</p><br><br>
 
 
 {% if not public %}
@@ -61,7 +61,7 @@
   <h3>Wishlist</h3>
 {% endif %}
 {% if empty_wishlist %}
-  <p>{{user.first_name}}'s wishlist is empty</p>
+  <p>{{user_to_view.first_name}}'s wishlist is empty</p>
 {% else %}
   <ul>
     {% for item in wishlist %}


### PR DESCRIPTION
Bugfix:
- After clicking on an arbitrary user's profile, the name that appears on the navbar will no longer change. It should remain the name of the logged in user

How to test:
- Go to /users and click on a few profiles. Make sure that the info on the Profile looks correct and the name on the navbar remains the name of the user that you are logged in as