### PR TITLE
Edit profile warning message

### DIFF
--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -1,5 +1,14 @@
-$(document).ready(function() {
+var editProfileFormTouched = function(first_name, last_name, bio, on_off_campus, profile_picture) {
+  return (
+    ($('#id_first_name').val() != first_name) ||
+    ($('#id_last_name').val() != last_name) ||
+    ($('#id_bio').val() != bio) ||
+    ($('#id_on_off_campus').val() != on_off_campus) ||
+    ($('#id_profile_picture').val() != profile_picture)
+  )
+}
 
+$(document).ready(function() {
   // show drop links on hover
   $(".links-drop, .links-box-wrapper").hover(function(){
       $('.links-box-wrapper').css('display','flex');
@@ -8,16 +17,34 @@ $(document).ready(function() {
   });
 
   //inject placeholder text into login forms
+  //on login page make login wrapper height of viewpoint
   if (location.pathname.substring(1) == "login/") {
     $('#id_username').attr('placeholder', 'Email Address');
     $('#id_password').attr('placeholder', 'Password');
-  }
-
-  //on login page make login wrapper height of viewpoint
-  if (location.pathname.substring(1) == "login/") {
     var height = $(window).height() - 86;
     $('.login-wrapper').css('height',height)
   }
+
+  if (location.pathname.substring(1) == "edit_profile/") {
+    let first_name = $('#id_first_name').val();
+    let last_name = $('#id_last_name').val();
+    let bio = $('#id_bio').val();
+    let on_off_campus = $('#id_on_off_campus').val();
+    let profile_picture = $('#id_profile_picture').val();
+    $(window).on("beforeunload", function() {
+      if(editProfileFormTouched(first_name, last_name, bio, on_off_campus, profile_picture)) {
+        return 'Are you sure you want to leave?'; // custom alert messages are no longer supported in most browsers :(
+      }
+    });
+    //turn off the beforeunload event upon form submission
+    $(document).ready(function() {
+      $("#edit_profile_form").on("submit", function(e) {
+        $(window).off("beforeunload");
+        return true;
+      });
+    });
+  }
+
 
 //displays a preview of profile picture in edit_profile page
   $(function() {

--- a/slug_trade/templates/slug_trade_app/edit_profile.html
+++ b/slug_trade/templates/slug_trade_app/edit_profile.html
@@ -8,7 +8,7 @@
 {% block body_block %}
   <div class="edit-profile-wrapper">
     <div class="edit-profile-body">
-      <form enctype="multipart/form-data" method="post">
+      <form enctype="multipart/form-data" method="post" id="edit_profile_form">
         {% csrf_token %}
         <div class="edit-profile-title">Edit Profile</div>
         <div class="profile-picture-wrapper">


### PR DESCRIPTION
New functionality:
-Browser should pop up a warning message when the user tries to leave the edit profile page without first saving their changes
- It should not pop up if the user hasn't changed anything or if the form is submitted

How to test:
1) Go to /edit_profile, don't change any fields and make sure you can navigate away from the page without getting a warning
2) Change one or more fields then try to navigate away from the page without saving. Make sure that you get a warning message
3) Try submitting the page as normal with some changes to make sure that it behaves normally and no warning comes up

Notes:
- Customizable warning messages are no longer supported by major browsers. I could not find a better way to create this effect with a custom message :(