### PR TITLE
Bugfix: Landing Dropdown

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -133,7 +133,7 @@ body {
   max-width: 300px;
   background: #fff;
   z-index: 9999999;
-  position: fixed;
+  position: absolute;
   top: 85px;
 }
 


### PR DESCRIPTION
Bug:
- When the user was not scrolled up at the top of the screen, the dropdown under Welcome, {user}! did not work correctly

How to test:
1) Log in to an account
2) Make try hovering over the welcome messages in different scroll positions on the screen
3) Make sure you can also click the links