### PR TITLE
Bugfix: Overflowing Text Fields

### DIFF
--- a/slug_trade/slug_trade_app/forms.py
+++ b/slug_trade/slug_trade_app/forms.py
@@ -88,7 +88,8 @@ class UserForm(UserCreationForm):
                                                               'placeholder': 'First Name',
                                                               'autocomplete':'given-name',
                                                               'required': True,
-                                                              'maxlength': 30}))
+                                                              'maxlength': 30,
+                                                              'size': 5})) # firefox requires a size attribute to avoid overflowing the container
 
     last_name = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-input',
                                                               'id': 'last-name',
@@ -96,7 +97,8 @@ class UserForm(UserCreationForm):
                                                               'placeholder': 'Last Name',
                                                               'autocomplete':'family-name',
                                                               'required': True,
-                                                              'maxlength': 30}))
+                                                              'maxlength': 30,
+                                                              'size': 5})) # firefox requires a size attribute to avoid overflowing the container
 
     email = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-input',
                                                               'name':'email',
@@ -112,14 +114,16 @@ class UserForm(UserCreationForm):
                                                               'autocomplete':'password',
                                                               'type': 'password',
                                                               'required': True,
-                                                              'maxlength': 256}))
+                                                              'maxlength': 256,
+                                                              'size': 5})) # firefox requires a size attribute to avoid overflowing the container
 
     password2 = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-input',
                                                               'name':'password',
                                                               'placeholder':'Verification Password',
                                                               'type': 'password',
                                                               'required': True,
-                                                              'maxlength': 256}))
+                                                              'maxlength': 256,
+                                                              'size': 5})) # firefox requires a size attribute to avoid overflowing the container
 
     def clean_email(self):
         username = self.cleaned_data["email"]


### PR DESCRIPTION
Bug:
- On Emma's machine (firefox only), some of the text fields overflowed their container

How to test:
- Load up firefox and go to the signup page and make sure it looks normal
- Decrease the width of the browser and make sure it still looks normal

Note:
- The only way I could reproduce this bug on my computer was by decreasing the screen size. I was able to fix it from my point of view, but it wasn't completely testable for me since I'm not running Ubuntu