### PR TITLE
Bugfix: Login Error Message

### DIFF
--- a/slug_trade/templates/slug_trade_app/login.html
+++ b/slug_trade/templates/slug_trade_app/login.html
@@ -19,6 +19,11 @@
         {{form.username.errors}}
         {{form.password}}
         {{form.password.errors}}
+        {% if form.errors %}
+            <p>
+                Wrong username or password. Try again.
+            </p>
+        {% endif %}
       </div>
 
       <div class="login-submit-wrapper">


### PR DESCRIPTION
Bug:
- No error message was shown when the user entered a wrong username/password on login

How to test:
- Enter a wrong username/password combo :P 