### PR TITLE
Add popularity counter db

### DIFF
--- a/slug_trade/slug_trade_app/management/commands/populate_db.py
+++ b/slug_trade/slug_trade_app/management/commands/populate_db.py
@@ -208,6 +208,7 @@ class Command(BaseCommand):
                                category=self.categories[picture],
                                description=fake.text(),
                                trade_options=random.choice(['0','2','3']))
+            item.bid_counter = random.choice(range(100))
             item.save()
 
             # get the item image from its name

--- a/slug_trade/slug_trade_app/management/commands/populate_db.py
+++ b/slug_trade/slug_trade_app/management/commands/populate_db.py
@@ -168,6 +168,7 @@ class Command(BaseCommand):
 
         # create the debug item
         item = models.Item(user=user, name='test', price='5.99', category='C', description='placeholder')
+        item.bid_counter = random.choice(range(100))
         item.save()
 
         # get the debug image to use as the item image


### PR DESCRIPTION
# Testing
after pulling branch and renewing db do the following:

In the appropriate directory call python manage.py shell
This will load the Django database specific prompt
Enter The following in the python prompt to view the counters for all of the items

from slug_trade_app.models import Item
for item in Item.objects.all():
    print(item.bid_counter)

You should see a range of randomly chosen numbers printed out.