### PR TITLE
Add closet item refactor

### DIFF
--- a/slug_trade/slug_trade_app/forms.py
+++ b/slug_trade/slug_trade_app/forms.py
@@ -63,10 +63,8 @@ class ClosetItemPhotos(forms.Form):
     image5 = forms.FileField(required=False)
     def __init__(self, *args, **kwargs):
         super(ClosetItemPhotos, self).__init__(*args, **kwargs)
-        self.fields['image1'].widget.attrs.update({'accept': 'image/*',
-                                                   'class': 'add-closet-wrapper-input'})
-        self.fields['image2'].widget.attrs.update({'accept': 'image/*',
-                                                   'class': 'add-closet-wrapper-input'})
+        self.fields['image1'].widget.attrs.update({'accept': 'image/*', 'class': 'add-closet-wrapper-input'})
+        self.fields['image2'].widget.attrs.update({'accept': 'image/*', 'class': 'add-closet-wrapper-input'})
         self.fields['image3'].widget.attrs.update({'accept': 'image/*', 'class': 'add-closet-wrapper-input'})
         self.fields['image4'].widget.attrs.update({'accept': 'image/*', 'class': 'add-closet-wrapper-input'})
         self.fields['image5'].widget.attrs.update({'accept': 'image/*', 'class': 'add-closet-wrapper-input'})

--- a/slug_trade/slug_trade_app/forms.py
+++ b/slug_trade/slug_trade_app/forms.py
@@ -63,7 +63,7 @@ class ClosetItemPhotos(forms.Form):
     image5 = forms.FileField(required=False)
     def __init__(self, *args, **kwargs):
         super(ClosetItemPhotos, self).__init__(*args, **kwargs)
-        self.fields['image1'].widget.attrs.update({'required': True, 'accept': 'image/*',
+        self.fields['image1'].widget.attrs.update({'accept': 'image/*',
                                                    'class': 'add-closet-wrapper-input'})
         self.fields['image2'].widget.attrs.update({'accept': 'image/*',
                                                    'class': 'add-closet-wrapper-input'})

--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -236,7 +236,6 @@ def add_closet_item(request):
         photos = ClosetItemPhotos(request.POST, photos_data)
 
         if form.is_valid():
-            print('form is valid!')
             item = form.save(commit=False)
             item.user = request.user
             if item.price < 0:
@@ -244,7 +243,6 @@ def add_closet_item(request):
             form.save()
 
             if photos.is_valid():
-                print('photos is valid!')
                 insert = ItemImage(
                     item = item,
                     image1 = image1,

--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -196,10 +196,47 @@ def edit_profile(request):
 def add_closet_item(request):
     if request.method == 'POST':
         form = ClosetItem(request.POST)
-        photos = ClosetItemPhotos(request.POST, request.FILES)
+
+        pics = []
+        files = request.FILES
+
+        if files.get('image1', False): pics.append(files['image1'])
+        if files.get('image2', False): pics.append(files['image2'])
+        if files.get('image3', False): pics.append(files['image3'])
+        if files.get('image4', False): pics.append(files['image4'])
+        if files.get('image5', False): pics.append(files['image5'])
+
+        image1 = pics.pop(0)
+
+        if len(pics) >= 1:
+            image2 = pics.pop(0);
+        else:
+            image2 = None
+        if len(pics) >= 1:
+            image3 = pics.pop(0);
+        else:
+            image3 = None
+        if len(pics) >= 1:
+            image4 = pics.pop(0);
+        else:
+            image4 = None
+        if len(pics) >= 1:
+            image5 = pics.pop(0);
+        else:
+            image5 = None
+
+        photos_data = {
+            'image1': image1,
+            'image2': image2,
+            'image3': image3,
+            'image4': image4,
+            'image5': image5
+        }
+
+        photos = ClosetItemPhotos(request.POST, photos_data)
 
         if form.is_valid():
-            print('form is valid')
+            print('form is valid!')
             item = form.save(commit=False)
             item.user = request.user
             if item.price < 0:
@@ -207,53 +244,15 @@ def add_closet_item(request):
             form.save()
 
             if photos.is_valid():
-                print('photos. is valid!')
-
-                pics = []
-                files = request.FILES
-
-                if files.get('image1', False): pics.append(files['image1'])
-                if files.get('image2', False): pics.append(files['image2'])
-                if files.get('image3', False): pics.append(files['image3'])
-                if files.get('image4', False): pics.append(files['image4'])
-                if files.get('image5', False): pics.append(files['image5'])
-
-                if len(pics) == 1:
-                    insert = ItemImage(
-                        item=item,
-                        image1=pics[0]
-                    )
-                elif len(pics) == 2:
-                    insert = ItemImage(
-                        item=item,
-                        image1=pics[0],
-                        image2=pics[1]
-                    )
-                elif len(pics) == 3:
-                    insert = ItemImage(
-                        item=item,
-                        image1=pics[0],
-                        image2=pics[1],
-                        image3=pics[2]
-                    )
-                elif len(pics) == 4:
-                    insert = ItemImage(
-                        item=item,
-                        image1=pics[0],
-                        image2=pics[1],
-                        image3=pics[2],
-                        image4=pics[3]
-                    )
-                elif len(pics) == 5:
-                    insert = ItemImage(
-                        item=item,
-                        image1=pics[0],
-                        image2=pics[1],
-                        image3=pics[2],
-                        image4=pics[3],
-                        image5=pics[4]
-                    )
-
+                print('photos is valid!')
+                insert = ItemImage(
+                    item = item,
+                    image1 = image1,
+                    image2 = image2,
+                    image3 = image3,
+                    image4 = image4,
+                    image5 = image5
+                )
                 insert.save()
 
         return redirect('/profile')

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1155,12 +1155,52 @@ margin-left: 10px;
   padding-top: 25px;
 }
 
+.add-closet-photos-inner-wrapper {
+  padding-top: 20px;
+  display:flex;
+  justify-content:space-between;
+  flex-wrap:wrap;
+}
+
+.add-closet-photos-inner-wrapper:after{
+  content: '';
+}
+
 .add-item-picture-wrapper {
-  border-bottom: 1px solid #d6d6d6;
-  padding: 0 10px;
+
+}
+
+.add-closet-photos-inner-wrapper img {
+  margin: auto;
+  display: block;
+}
+
+.add-closet-photos-inner-wrapper input[type=file] {
+  display: none;
+}
+
+.add-closet-item-img {
+  width: 90px;
+}
+
+.add-closet-item-choose-photo {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  text-decoration: none;
+  border-radius: 5px;
+  font-weight: 900;
+  background-color: #fff;
+  color: #333;
+  font-size: 14px;
+  height: 40px;
+  width: 110px;
+  border: 1px solid #333;
+}
+
+.add-closet-item-choose-photo:hover{
+  background: #333;
+  color: #fff;
 }
 
 .add-item-price {

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1167,7 +1167,18 @@ margin-left: 10px;
 }
 
 .add-item-picture-wrapper {
+  position: relative;
+  display: inline-block;
+}
 
+.add-item-picture-wrapper .close:before {
+  content: '✕';
+}
+.add-item-picture-wrapper .close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  cursor: pointer;
 }
 
 .add-closet-photos-inner-wrapper img {

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1212,6 +1212,14 @@ margin-left: 10px;
   cursor: pointer;
 }
 
+#add_picture:hover {
+  opacity: 0.6;
+}
+
+#add-closet-submit {
+  width: 100%;
+}
+
 .add-closet-item-choose-photo {
   display: block;
   margin: auto;

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1078,7 +1078,7 @@ margin-left: 10px;
 
 .add-item-body {
   width: 100%;
-  max-width: 600px;
+  max-width: 700px;
   display: flex;
   flex-direction: column;
 }
@@ -1158,8 +1158,7 @@ margin-left: 10px;
 .add-closet-photos-inner-wrapper {
   padding-top: 20px;
   display:flex;
-  justify-content:space-between;
-  flex-wrap:wrap;
+  flex-direction: row;
 }
 
 .add-closet-photos-inner-wrapper:after{
@@ -1167,8 +1166,14 @@ margin-left: 10px;
 }
 
 .add-item-picture-wrapper {
-  position: relative;
+  margin:0 5px;
+}
+
+.add-item-picture-inner-wrapper {
+  height: 130px;
+  width: 130px;
   display: inline-block;
+  position: relative;
 }
 
 .add-item-picture-wrapper .close:before {
@@ -1181,9 +1186,17 @@ margin-left: 10px;
   cursor: pointer;
 }
 
-.add-closet-photos-inner-wrapper img {
+.add-item-picture-inner-wrapper img {
+  max-height: 100%;
+  max-width: 85%;
+  width: auto;
+  height: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   margin: auto;
-  display: block;
 }
 
 .add-closet-photos-inner-wrapper input[type=file] {
@@ -1191,13 +1204,17 @@ margin-left: 10px;
 }
 
 .add-closet-item-img {
-  width: 90px;
+  max-width: 90px;
+  max-height: 90px;
+}
+
+#add_picture {
+  cursor: pointer;
 }
 
 .add-closet-item-choose-photo {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
+  margin: auto;
   text-decoration: none;
   border-radius: 5px;
   font-weight: 900;
@@ -1207,11 +1224,19 @@ margin-left: 10px;
   height: 40px;
   width: 110px;
   border: 1px solid #333;
+  position: relative;
+  top: 115px;
 }
 
 .add-closet-item-choose-photo:hover{
   background: #333;
   color: #fff;
+}
+
+#add-closet-add-photo {
+  position: relative;
+  top: 105px;
+  text-align: center;
 }
 
 .add-item-price {

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -8,6 +8,12 @@ var editProfileFormTouched = function(first_name, last_name, bio, on_off_campus,
   )
 };
 
+// add closet items helper functions and variables
+
+var add_closet_item_image = 'https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg';
+var closet_photos = undefined;
+var closet_files = undefined;
+
 var countHiddenPhotos = function() {
   var num_photos = 5;
   var id = '#picture';
@@ -53,33 +59,36 @@ var showAddPhotoButton = function() {
   }
 };
 
-  function swap(id1, id2) {
-    obj1 = document.getElementById(id1);
-    obj2 = document.getElementById(id2);
-    // create marker element and insert it where obj1 is
-    var temp = document.createElement("div");
-    obj1.parentNode.insertBefore(temp, obj1);
-
-    // move obj1 to right before obj2
-    obj2.parentNode.insertBefore(obj1, obj2);
-
-    // move obj2 to right before where obj1 used to be
-    temp.parentNode.insertBefore(obj2, temp);
-
-    // remove temporary marker node
-    temp.parentNode.removeChild(temp);
-
-    temp = id1;
-    var index1 = closet_photos.indexOf(id1);
-    var index2 = closet_photos.indexOf(id2)
-    closet_photos[index1] = id2;
-    closet_photos[index2] = id1;
-
-    temp = closet_files[index1];
-    closet_files[index1] = closet_files[index2];
-    closet_files[index2] = temp;
+var swapArrayElements = function(arr, index1, index2) {
+  var temp = arr[index1];
+  arr[index1] = arr[index2];
+  arr[index2] = temp;
 }
 
+var swapDivElements = function(id1, id2) {
+  obj1 = document.getElementById(id1);
+  obj2 = document.getElementById(id2);
+  // create marker element and insert it where obj1 is
+  var temp = document.createElement("div");
+  obj1.parentNode.insertBefore(temp, obj1);
+
+  // move obj1 to right before obj2
+  obj2.parentNode.insertBefore(obj1, obj2);
+
+  // move obj2 to right before where obj1 used to be
+  temp.parentNode.insertBefore(obj2, temp);
+
+  // remove temporary marker node
+  temp.parentNode.removeChild(temp);
+
+  var index1 = closet_photos.indexOf(id1);
+  var index2 = closet_photos.indexOf(id2)
+  swapArrayElements(closet_photos, index1, index2);
+  swapArrayElements(closet_files, index1, index2);
+}
+
+// function moves any unselected photos to the back of the container, so that
+// the user is always entering photos at the back of the list
 var shuffle = function() {
   for(var i=0; i<closet_files.length-1; i++) {
     curr_id = closet_files[i];
@@ -87,18 +96,12 @@ var shuffle = function() {
     if($('#'+curr_id).val() == '' && $('#'+next_id).val() != '') {
       var photo1 = closet_photos[closet_files.indexOf(curr_id)];
       var photo2 = closet_photos[closet_files.indexOf(next_id)];
-      swap(photo1, photo2);
+      swapDivElements(photo1, photo2);
     }
   }
 }
 
-var add_closet_item_image = 'https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg';
-var closet_photos = undefined;
-
 $(document).ready(function() {
-  closet_photos = ['picture1', 'picture2', 'picture3', 'picture4', 'picture5'];
-  closet_files = ['id_image1', 'id_image2', 'id_image3', 'id_image4', 'id_image5'];
-
   // show drop links on hover
   $(".links-drop, .links-box-wrapper").hover(function(){
       $('.links-box-wrapper').css('display','flex');
@@ -187,7 +190,12 @@ $(document).ready(function() {
 
 });
 
-  // ---- These are functions that handle the hiding/showing of images
+  // --- ADD CLOSET ITEM EVENTS --------------------------------------------------------------------------
+
+  // ---- These functions show photo previews in add closet itm
+  closet_photos = ['picture1', 'picture2', 'picture3', 'picture4', 'picture5'];
+  closet_files = ['id_image1', 'id_image2', 'id_image3', 'id_image4', 'id_image5'];
+
   $(function() {
     $('#id_image1').change(function() {
       console.log('1 changed!');
@@ -268,6 +276,8 @@ $(document).ready(function() {
     });
   });
 
+  //---- These functions handle the logic when you click an x on the photos
+
   $(function() {
     $('#close_img1').click(function() {
       console.log('1 closed!');
@@ -318,6 +328,8 @@ $(document).ready(function() {
     });
   });
 
+  // ---- This function handles the logic when you click add photo
+
   $(function() {
     $('#add_photo_img').click(function() {
       if(canAddPhoto()) {
@@ -340,6 +352,7 @@ $(document).ready(function() {
     });
   });
 
+  // -- Validation for add closet item form
   $(function() {
     $('#add-closet-submit').click(function() {
       if($('#id_name').val() != '' && $('#id_description').val() != '' && countSelectedPhotos() == 0) {
@@ -348,7 +361,10 @@ $(document).ready(function() {
     });
   });
 
+// ------------------ END OF ADD ADD CLOSET ITEM FUNCTIONS --------------------
   //this function deletes an item from the wishlist on the profile
+
+  // ---------------- WISHLIST FUNCTIONS ------------------------------------
   $(function() {
     $('.delete_from_wishlist').click(function() {
       let id = $(this).val();
@@ -369,6 +385,8 @@ $(document).ready(function() {
     $('#wishlist_item_description').focus();
   }
 });
+
+// --------------- END OF WISHLIST FUNCTIONS ------------------------
 
 //Smooth scrolling on steps
 document.querySelectorAll('a[href^="#"]').forEach(anchor => {

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -21,6 +21,19 @@ var countHiddenPhotos = function() {
   return count;
 };
 
+var countSelectedPhotos = function() {
+  var num_photos = 5;
+  var id = '#id_image';
+  var count = 0;
+  for(var i=1; i<=num_photos; i++) {
+    var current_id = id+i;
+    if($(current_id).val() != '') {
+      count++;
+    }
+  }
+  return count;
+};
+
 var canAddPhoto = function() {
   if(countHiddenPhotos() == 5) {
     return true;
@@ -323,6 +336,14 @@ $(document).ready(function() {
         shuffle();
       } else {
         alert('You must choose a photo first.');
+      }
+    });
+  });
+
+  $(function() {
+    $('#add-closet-submit').click(function() {
+      if($('#id_name').val() != '' && $('#id_description').val() != '' && countSelectedPhotos() == 0) {
+        alert('You must add a photo!');
       }
     });
   });

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -195,7 +195,11 @@ $(document).ready(function() {
   // ---- These functions show photo previews in add closet itm
   closet_photos = ['picture1', 'picture2', 'picture3', 'picture4', 'picture5'];
   closet_files = ['id_image1', 'id_image2', 'id_image3', 'id_image4', 'id_image5'];
-
+  $('#id_image1').attr('novalidate', 'novalidate');
+  $('#id_image2').attr('novalidate', 'novalidate');
+  $('#id_image3').attr('novalidate', 'novalidate');
+  $('#id_image4').attr('novalidate', 'novalidate');
+  $('#id_image5').attr('novalidate', 'novalidate');
   $(function() {
     $('#id_image1').change(function() {
       var input = this;
@@ -323,6 +327,7 @@ $(document).ready(function() {
   $(function() {
     $('#add_picture').click(function() {
       if(canAddPhoto()) {
+        shuffle();
         var id = '#picture';
         var num_photos = 5;
         for(var i=1; i<=num_photos; i++) {
@@ -335,7 +340,6 @@ $(document).ready(function() {
         if(countHiddenPhotos() == 0) {
           $('#add_picture').css('display', 'none');
         }
-        shuffle();
       } else {
         alert('You must choose a photo first.');
       }
@@ -344,9 +348,10 @@ $(document).ready(function() {
 
   // -- Validation for add closet item form
   $(function() {
-    $('#add-closet-submit').click(function() {
+    $('#add-closet-submit').click(function(event) {
       if($('#id_name').val() != '' && $('#id_description').val() != '' && countSelectedPhotos() == 0) {
         alert('You must add a photo!');
+        event.preventDefault();
       }
     });
   });

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -198,7 +198,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image1').change(function() {
-      console.log('1 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -214,7 +213,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image2').change(function() {
-      console.log('2 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -230,7 +228,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image3').change(function() {
-      console.log('3 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -246,7 +243,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image4').change(function() {
-      console.log('4 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -262,7 +258,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image5').change(function() {
-      console.log('5 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -280,7 +275,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img1').click(function() {
-      console.log('1 closed!');
       $('#add_closet_img1').attr('src', add_closet_item_image);
       $('#id_image1').val('');
       $('#picture1').css('display', 'none');
@@ -290,7 +284,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img2').click(function() {
-      console.log('2 closed!');
       $('#add_closet_img2').attr('src', add_closet_item_image);
       $('#id_image2').val('');
       $('#picture2').css('display', 'none');
@@ -300,7 +293,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img3').click(function() {
-      console.log('3 closed!');
       $('#add_closet_img3').attr('src', add_closet_item_image);
       $('#id_image3').val('');
       $('#picture3').css('display', 'none');
@@ -310,7 +302,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img4').click(function() {
-      console.log('4 closed!');
       $('#add_closet_img4').attr('src', add_closet_item_image);
       $('#id_image4').val('');
       $('#picture4').css('display', 'none');
@@ -320,7 +311,6 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img5').click(function() {
-      console.log('5 closed!');
       $('#add_closet_img5').attr('src', add_closet_item_image);
       $('#id_image5').val('');
       $('#picture5').css('display', 'none');
@@ -331,7 +321,7 @@ $(document).ready(function() {
   // ---- This function handles the logic when you click add photo
 
   $(function() {
-    $('#add_photo_img').click(function() {
+    $('#add_picture').click(function() {
       if(canAddPhoto()) {
         var id = '#picture';
         var num_photos = 5;

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -22,28 +22,70 @@ var countHiddenPhotos = function() {
 };
 
 var canAddPhoto = function() {
-  var num_photos = 5;
-  var id = '#picture';
-  console.log('here');
-  for(var i=num_photos; i>=1; i--) {
-    var current_id = id+i;
-    if($(current_id).css('display') == 'block') {
-      console.log($('#image'+i).val());
-      return $('#image'+i).val() != '';
+  if(countHiddenPhotos() == 5) {
+    return true;
+  }
+  for(var i=closet_photos.length-1; i>=0; i--) {
+    var current_id = closet_photos[i];
+    if($('#' + current_id).css('display') == 'block') {
+      var image = $('#' + closet_files[i]).val();
+      return image != '';
     }
   }
 }
 
 var showAddPhotoButton = function() {
-  console.log(canAddPhoto());
   if(countHiddenPhotos() > 0) {
     $('#add_picture').css('display', 'block');
   }
 };
 
+  function swap(id1, id2) {
+    obj1 = document.getElementById(id1);
+    obj2 = document.getElementById(id2);
+    // create marker element and insert it where obj1 is
+    var temp = document.createElement("div");
+    obj1.parentNode.insertBefore(temp, obj1);
+
+    // move obj1 to right before obj2
+    obj2.parentNode.insertBefore(obj1, obj2);
+
+    // move obj2 to right before where obj1 used to be
+    temp.parentNode.insertBefore(obj2, temp);
+
+    // remove temporary marker node
+    temp.parentNode.removeChild(temp);
+
+    temp = id1;
+    var index1 = closet_photos.indexOf(id1);
+    var index2 = closet_photos.indexOf(id2)
+    closet_photos[index1] = id2;
+    closet_photos[index2] = id1;
+
+    temp = closet_files[index1];
+    closet_files[index1] = closet_files[index2];
+    closet_files[index2] = temp;
+}
+
+var shuffle = function() {
+  for(var i=0; i<closet_files.length-1; i++) {
+    curr_id = closet_files[i];
+    next_id = closet_files[i+1];
+    if($('#'+curr_id).val() == '' && $('#'+next_id).val() != '') {
+      var photo1 = closet_photos[closet_files.indexOf(curr_id)];
+      var photo2 = closet_photos[closet_files.indexOf(next_id)];
+      swap(photo1, photo2);
+    }
+  }
+}
+
 var add_closet_item_image = 'https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg';
+var closet_photos = undefined;
 
 $(document).ready(function() {
+  closet_photos = ['picture1', 'picture2', 'picture3', 'picture4', 'picture5'];
+  closet_files = ['id_image1', 'id_image2', 'id_image3', 'id_image4', 'id_image5'];
+
   // show drop links on hover
   $(".links-drop, .links-box-wrapper").hover(function(){
       $('.links-box-wrapper').css('display','flex');
@@ -135,6 +177,7 @@ $(document).ready(function() {
   // ---- These are functions that handle the hiding/showing of images
   $(function() {
     $('#id_image1').change(function() {
+      console.log('1 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -150,6 +193,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image2').change(function() {
+      console.log('2 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -165,6 +209,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image3').change(function() {
+      console.log('3 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -180,6 +225,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image4').change(function() {
+      console.log('4 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -195,6 +241,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#id_image5').change(function() {
+      console.log('5 changed!');
       var input = this;
       var url = $(this).val();
       var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
@@ -210,17 +257,17 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img1').click(function() {
+      console.log('1 closed!');
       $('#add_closet_img1').attr('src', add_closet_item_image);
       $('#id_image1').val('');
-      if(countHiddenPhotos() < 4) {
-        $('#picture1').css('display', 'none');
-        showAddPhotoButton();
-      }
+      $('#picture1').css('display', 'none');
+      showAddPhotoButton();
     });
   });
 
   $(function() {
     $('#close_img2').click(function() {
+      console.log('2 closed!');
       $('#add_closet_img2').attr('src', add_closet_item_image);
       $('#id_image2').val('');
       $('#picture2').css('display', 'none');
@@ -230,6 +277,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img3').click(function() {
+      console.log('3 closed!');
       $('#add_closet_img3').attr('src', add_closet_item_image);
       $('#id_image3').val('');
       $('#picture3').css('display', 'none');
@@ -239,6 +287,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img4').click(function() {
+      console.log('4 closed!');
       $('#add_closet_img4').attr('src', add_closet_item_image);
       $('#id_image4').val('');
       $('#picture4').css('display', 'none');
@@ -248,6 +297,7 @@ $(document).ready(function() {
 
   $(function() {
     $('#close_img5').click(function() {
+      console.log('5 closed!');
       $('#add_closet_img5').attr('src', add_closet_item_image);
       $('#id_image5').val('');
       $('#picture5').css('display', 'none');
@@ -257,17 +307,22 @@ $(document).ready(function() {
 
   $(function() {
     $('#add_photo_img').click(function() {
-      var id = '#picture';
-      var num_photos = 5;
-      for(var i=1; i<=num_photos; i++) {
-        var current_id = id+i;
-        if($(current_id).css('display') == 'none') {
-          $(current_id).css('display', 'block');
-          break;
+      if(canAddPhoto()) {
+        var id = '#picture';
+        var num_photos = 5;
+        for(var i=1; i<=num_photos; i++) {
+          var current_id = id+i;
+          if($(current_id).css('display') == 'none') {
+            $(current_id).css('display', 'block');
+            break;
+          }
         }
-      }
-      if(countHiddenPhotos() == 0) {
-        $('#add_picture').css('display', 'none');
+        if(countHiddenPhotos() == 0) {
+          $('#add_picture').css('display', 'none');
+        }
+        shuffle();
+      } else {
+        alert('You must choose a photo first.');
       }
     });
   });

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -195,11 +195,7 @@ $(document).ready(function() {
   // ---- These functions show photo previews in add closet itm
   closet_photos = ['picture1', 'picture2', 'picture3', 'picture4', 'picture5'];
   closet_files = ['id_image1', 'id_image2', 'id_image3', 'id_image4', 'id_image5'];
-  $('#id_image1').attr('novalidate', 'novalidate');
-  $('#id_image2').attr('novalidate', 'novalidate');
-  $('#id_image3').attr('novalidate', 'novalidate');
-  $('#id_image4').attr('novalidate', 'novalidate');
-  $('#id_image5').attr('novalidate', 'novalidate');
+
   $(function() {
     $('#id_image1').change(function() {
       var input = this;
@@ -283,6 +279,7 @@ $(document).ready(function() {
       $('#id_image1').val('');
       $('#picture1').css('display', 'none');
       showAddPhotoButton();
+      shuffle();
     });
   });
 
@@ -292,6 +289,7 @@ $(document).ready(function() {
       $('#id_image2').val('');
       $('#picture2').css('display', 'none');
       showAddPhotoButton();
+      shuffle();
     });
   });
 
@@ -301,6 +299,7 @@ $(document).ready(function() {
       $('#id_image3').val('');
       $('#picture3').css('display', 'none');
       showAddPhotoButton();
+      shuffle();
     });
   });
 
@@ -310,6 +309,7 @@ $(document).ready(function() {
       $('#id_image4').val('');
       $('#picture4').css('display', 'none');
       showAddPhotoButton();
+      shuffle();
     });
   });
 
@@ -319,6 +319,7 @@ $(document).ready(function() {
       $('#id_image5').val('');
       $('#picture5').css('display', 'none');
       showAddPhotoButton();
+      shuffle();
     });
   });
 

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -334,6 +334,7 @@ $(document).ready(function() {
           var current_id = id+i;
           if($(current_id).css('display') == 'none') {
             $(current_id).css('display', 'block');
+            $('#id_image'+i).trigger('click');
             break;
           }
         }

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -98,83 +98,82 @@ $(document).ready(function() {
 });
 
   // ---- These are functions that handle the hiding/showing of images
-    // get it to show the next one
- $(function(){
-   $('#show_2').click(function(e){
-       e.preventDefault();
-     $('#picture_2').css('display','flex');
-       $('#show_2').hide()
-   })
- })
-
- $(function(){
-   $('#show_3').click(function(e){
-       e.preventDefault();
-     $('#picture_3').css('display','flex');
-     $('#show_3').hide()
-   })
- })
-
- $(function(){
-   $('#show_4').click(function(e){
-       e.preventDefault();
-     $('#picture_4').css('display','flex');
-     $('#show_4').hide()
-   })
- })
-
- $(function(){
-   $('#show_5').click(function(e){
-       e.preventDefault();
-     $('#picture_5').css('display','flex');
-     $('#show_5').hide()
-   })
- })
-
-
-
-
-  // ---- all of these functions clear images out of the file selectors inside add_closet_item ----
   $(function() {
-    $('#clear_image1').click(function() {
-      $("#id_image1").val("");
-
+    $('#id_image1').change(function() {
+      var input = this;
+      var url = $(this).val();
+      var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
+      if(input.files && input.files[0] && (ext == "gif" || ext == "png" || ext == "jpeg" || ext == "jpg")) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          $('#add_closet_img1').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+      }
     });
   });
 
   $(function() {
-    $('#clear_image2').click(function() {
-      $("#id_image2").val("");
-      $("#picture_2").hide();
-      $('#show_2').show();
+    $('#id_image2').change(function() {
+      var input = this;
+      var url = $(this).val();
+      var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
+      if(input.files && input.files[0] && (ext == "gif" || ext == "png" || ext == "jpeg" || ext == "jpg")) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          $('#add_closet_img2').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+      }
     });
   });
 
   $(function() {
-    $('#clear_image3').click(function() {
-      $("#id_image3").val("");
-      $("#picture_3").hide();
-      $('#show_3').show();
+    $('#id_image3').change(function() {
+      var input = this;
+      var url = $(this).val();
+      var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
+      if(input.files && input.files[0] && (ext == "gif" || ext == "png" || ext == "jpeg" || ext == "jpg")) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          $('#add_closet_img3').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+      }
     });
   });
 
   $(function() {
-    $('#clear_image4').click(function() {
-      $("#id_image4").val("");
-      $("#picture_4").hide();
-      $('#show_4').show();
+    $('#id_image4').change(function() {
+      var input = this;
+      var url = $(this).val();
+      var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
+      if(input.files && input.files[0] && (ext == "gif" || ext == "png" || ext == "jpeg" || ext == "jpg")) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          $('#add_closet_img4').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+      }
     });
   });
 
   $(function() {
-    $('#clear_image5').click(function() {
-      $("#id_image5").val("");
-      $("#picture_5").hide();
-      //This needs to show the plus sign above it which is plus sign for show_5
-      $('#show_5').show()
+    $('#id_image5').change(function() {
+      var input = this;
+      var url = $(this).val();
+      var ext = url.substring(url.lastIndexOf('.') + 1).toLowerCase();
+      if(input.files && input.files[0] && (ext == "gif" || ext == "png" || ext == "jpeg" || ext == "jpg")) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          $('#add_closet_img5').attr('src', e.target.result);
+        }
+        reader.readAsDataURL(input.files[0]);
+      }
     });
   });
-  // -- endblock -----
+
+
   //this function deletes an item from the wishlist on the profile
   $(function() {
     $('.delete_from_wishlist').click(function() {

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -6,7 +6,42 @@ var editProfileFormTouched = function(first_name, last_name, bio, on_off_campus,
     ($('#id_on_off_campus').val() != on_off_campus) ||
     ($('#id_profile_picture').val() != profile_picture)
   )
+};
+
+var countHiddenPhotos = function() {
+  var num_photos = 5;
+  var id = '#picture';
+  var count = 0;
+  for(var i=1; i<=num_photos; i++) {
+    var current_id = id+i;
+    if($(current_id).css('display') == 'none') {
+      count++;
+    }
+  }
+  return count;
+};
+
+var canAddPhoto = function() {
+  var num_photos = 5;
+  var id = '#picture';
+  console.log('here');
+  for(var i=num_photos; i>=1; i--) {
+    var current_id = id+i;
+    if($(current_id).css('display') == 'block') {
+      console.log($('#image'+i).val());
+      return $('#image'+i).val() != '';
+    }
+  }
 }
+
+var showAddPhotoButton = function() {
+  console.log(canAddPhoto());
+  if(countHiddenPhotos() > 0) {
+    $('#add_picture').css('display', 'block');
+  }
+};
+
+var add_closet_item_image = 'https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg';
 
 $(document).ready(function() {
   // show drop links on hover
@@ -173,6 +208,69 @@ $(document).ready(function() {
     });
   });
 
+  $(function() {
+    $('#close_img1').click(function() {
+      $('#add_closet_img1').attr('src', add_closet_item_image);
+      $('#id_image1').val('');
+      if(countHiddenPhotos() < 4) {
+        $('#picture1').css('display', 'none');
+        showAddPhotoButton();
+      }
+    });
+  });
+
+  $(function() {
+    $('#close_img2').click(function() {
+      $('#add_closet_img2').attr('src', add_closet_item_image);
+      $('#id_image2').val('');
+      $('#picture2').css('display', 'none');
+      showAddPhotoButton();
+    });
+  });
+
+  $(function() {
+    $('#close_img3').click(function() {
+      $('#add_closet_img3').attr('src', add_closet_item_image);
+      $('#id_image3').val('');
+      $('#picture3').css('display', 'none');
+      showAddPhotoButton();
+    });
+  });
+
+  $(function() {
+    $('#close_img4').click(function() {
+      $('#add_closet_img4').attr('src', add_closet_item_image);
+      $('#id_image4').val('');
+      $('#picture4').css('display', 'none');
+      showAddPhotoButton();
+    });
+  });
+
+  $(function() {
+    $('#close_img5').click(function() {
+      $('#add_closet_img5').attr('src', add_closet_item_image);
+      $('#id_image5').val('');
+      $('#picture5').css('display', 'none');
+      showAddPhotoButton();
+    });
+  });
+
+  $(function() {
+    $('#add_photo_img').click(function() {
+      var id = '#picture';
+      var num_photos = 5;
+      for(var i=1; i<=num_photos; i++) {
+        var current_id = id+i;
+        if($(current_id).css('display') == 'none') {
+          $(current_id).css('display', 'block');
+          break;
+        }
+      }
+      if(countHiddenPhotos() == 0) {
+        $('#add_picture').css('display', 'none');
+      }
+    });
+  });
 
   //this function deletes an item from the wishlist on the profile
   $(function() {

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -329,13 +329,11 @@ $(document).ready(function() {
     $('#add_picture').click(function() {
       if(canAddPhoto()) {
         shuffle();
-        var id = '#picture';
-        var num_photos = 5;
-        for(var i=1; i<=num_photos; i++) {
-          var current_id = id+i;
+        for(var i=0; i<closet_photos.length; i++) {
+          var current_id = '#'+closet_photos[i];
           if($(current_id).css('display') == 'none') {
             $(current_id).css('display', 'block');
-            $('#id_image'+i).trigger('click');
+            $('#'+closet_files[i]).trigger('click');
             break;
           }
         }

--- a/slug_trade/templates/slug_trade_app/add_closet_item.html
+++ b/slug_trade/templates/slug_trade_app/add_closet_item.html
@@ -64,6 +64,7 @@
                   <div>
                     <img id="add_closet_img1" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image1 }}
+                    <span id="close_img1" class="close"></span>
                     <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image1').click();">Choose Photo</button>
                   </div>
                 </div>
@@ -72,6 +73,7 @@
                   <div>
                     <img id="add_closet_img2" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image2 }}
+                    <span id="close_img2" class="close"></span>
                     <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image2').click();">Choose Photo</button>
                   </div>
                 </div>
@@ -80,6 +82,7 @@
                   <div>
                     <img id="add_closet_img3" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image3 }}
+                    <span id="close_img3" class="close"></span>
                     <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image3').click();">Choose Photo</button>
                   </div>
                 </div>
@@ -88,6 +91,7 @@
                   <div>
                     <img id="add_closet_img4" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image4 }}
+                    <span id="close_img4" class="close"></span>
                     <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image4').click();">Choose Photo</button>
                   </div>
                 </div>
@@ -96,6 +100,7 @@
                   <div>
                     <img id="add_closet_img5" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image5 }}
+                    <span id="close_img5" class="close"></span>
                     <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image5').click();">Choose Photo</button>
                   </div>
                 </div>

--- a/slug_trade/templates/slug_trade_app/add_closet_item.html
+++ b/slug_trade/templates/slug_trade_app/add_closet_item.html
@@ -114,7 +114,9 @@
               </div>
               <br>
               <br>
-              <input type="submit" name="" value="Save">
+              <br>
+              <br>
+              <input id="add-closet-submit" type="submit" name="" value="Add Item">
             </div>
 
         </div>

--- a/slug_trade/templates/slug_trade_app/add_closet_item.html
+++ b/slug_trade/templates/slug_trade_app/add_closet_item.html
@@ -60,48 +60,55 @@
             <div class="add-item-subtitle">Item Images</div>
 
               <div class="add-closet-photos-inner-wrapper">
-                <div class="add-item-picture-wrapper" id="picture1">
-                  <div>
+                <div class="add-item-picture-wrapper" id="picture1" style="display: none;">
+                  <div class="add-item-picture-inner-wrapper">
                     <img id="add_closet_img1" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image1 }}
                     <span id="close_img1" class="close"></span>
-                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image1').click();">Choose Photo</button>
+                    <button type="button" class="add-closet-item-choose-photo" onclick="document.getElementById('id_image1').click();">Choose Photo</button>
                   </div>
                 </div>
 
-                <div class="add-item-picture-wrapper" id="picture2">
-                  <div>
+                <div class="add-item-picture-wrapper" id="picture2" style="display: none;">
+                  <div class="add-item-picture-inner-wrapper">
                     <img id="add_closet_img2" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image2 }}
                     <span id="close_img2" class="close"></span>
-                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image2').click();">Choose Photo</button>
+                    <button type="button" class="add-closet-item-choose-photo" onclick="document.getElementById('id_image2').click();">Choose Photo</button>
                   </div>
                 </div>
 
-                <div class="add-item-picture-wrapper" id="picture3">
-                  <div>
+                <div class="add-item-picture-wrapper" id="picture3" style="display: none;">
+                  <div class="add-item-picture-inner-wrapper">
                     <img id="add_closet_img3" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image3 }}
                     <span id="close_img3" class="close"></span>
-                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image3').click();">Choose Photo</button>
+                    <button type="button" class="add-closet-item-choose-photo" onclick="document.getElementById('id_image3').click();">Choose Photo</button>
                   </div>
                 </div>
 
-                <div class="add-item-picture-wrapper" id="picture4">
-                  <div>
+                <div class="add-item-picture-wrapper" id="picture4" style="display: none;">
+                  <div class="add-item-picture-inner-wrapper">
                     <img id="add_closet_img4" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image4 }}
                     <span id="close_img4" class="close"></span>
-                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image4').click();">Choose Photo</button>
+                    <button type="button" class="add-closet-item-choose-photo" onclick="document.getElementById('id_image4').click();">Choose Photo</button>
                   </div>
                 </div>
 
-                <div class="add-item-picture-wrapper" id="picture5">
-                  <div>
+                <div class="add-item-picture-wrapper" id="picture5" style="display: none;">
+                  <div class="add-item-picture-inner-wrapper">
                     <img id="add_closet_img5" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
                     {{ photos.image5 }}
                     <span id="close_img5" class="close"></span>
-                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image5').click();">Choose Photo</button>
+                    <button type="button" class="add-closet-item-choose-photo" onclick="document.getElementById('id_image5').click();">Choose Photo</button>
+                  </div>
+                </div>
+
+                <div class="add-item-picture-wrapper" id="add_picture" style="display: block">
+                  <div class="add-item-picture-inner-wrapper">
+                    <img id="add_photo_img" class="add-closet-item-img" src="http://icons.iconarchive.com/icons/iconsmind/outline/512/Add-icon.png"><br>
+                    <h4 id="add-closet-add-photo">Add Photo</h4>
                   </div>
                 </div>
               </div>

--- a/slug_trade/templates/slug_trade_app/add_closet_item.html
+++ b/slug_trade/templates/slug_trade_app/add_closet_item.html
@@ -59,38 +59,47 @@
 
             <div class="add-item-subtitle">Item Images</div>
 
-              <div class="add-item-picture-wrapper" id="picture1">
-                  {{ photos.image1 }}
-                  <h4 type="button" class="add-closet-remove-photo" style="display: inline" id="clear_image1">X</h4>
+              <div class="add-closet-photos-inner-wrapper">
+                <div class="add-item-picture-wrapper" id="picture1">
+                  <div>
+                    <img id="add_closet_img1" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
+                    {{ photos.image1 }}
+                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image1').click();">Choose Photo</button>
+                  </div>
+                </div>
+
+                <div class="add-item-picture-wrapper" id="picture2">
+                  <div>
+                    <img id="add_closet_img2" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
+                    {{ photos.image2 }}
+                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image2').click();">Choose Photo</button>
+                  </div>
+                </div>
+
+                <div class="add-item-picture-wrapper" id="picture3">
+                  <div>
+                    <img id="add_closet_img3" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
+                    {{ photos.image3 }}
+                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image3').click();">Choose Photo</button>
+                  </div>
+                </div>
+
+                <div class="add-item-picture-wrapper" id="picture4">
+                  <div>
+                    <img id="add_closet_img4" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
+                    {{ photos.image4 }}
+                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image4').click();">Choose Photo</button>
+                  </div>
+                </div>
+
+                <div class="add-item-picture-wrapper" id="picture5">
+                  <div>
+                    <img id="add_closet_img5" class="add-closet-item-img" src="https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg"><br>
+                    {{ photos.image5 }}
+                    <button class="add-closet-item-choose-photo" onclick="document.getElementById('id_image5').click();">Choose Photo</button>
+                  </div>
+                </div>
               </div>
-
-              <div class="add-item-picture-wrapper" id="picture_2">
-                  {{ photos.image2 }}
-                  <h4 class="add-closet-remove-photo" id="clear_image2">X</h4>
-              </div>
-
-
-              <div class="add-item-picture-wrapper" id="picture_3">
-                  {{ photos.image3 }}
-                  <h4 type="button" class="add-closet-remove-photo" id="clear_image3">X</h4>
-              </div>
-
-
-              <div class="add-item-picture-wrapper" id="picture_4">
-                  {{ photos.image4 }}
-                  <h4 type="button" class="add-closet-remove-photo" id="clear_image4">X</h4>
-              </div>
-
-
-              <div class="add-item-picture-wrapper" id="picture_5">
-                  {{ photos.image5 }}
-                  <h4 type="button" class="add-closet-remove-photo" style="display: inline" id="clear_image5">X</h4>
-              </div>
-
-              <h2 id="show_2" style="display:inline; text-decoration: none">+</h2>
-              <h2 id="show_3" style="display:inline; text-decoration: none">+</h2>
-              <h2 id="show_4" style="display:inline; text-decoration: none">+</h2>
-              <h2 id="show_5" style="display:inline; text-decoration: none">+</h2>
               <br>
               <br>
               <input type="submit" name="" value="Save">


### PR DESCRIPTION
New Functionality:
- Updated method of adding photos to closet items
- Increased the width of the add closet items panel (small css change)

How to test:
- Add and delete a whole bunch of items in a whole bunch of different ways!!
- Make sure these properties are always upheld:
  - Items with the ? are always on the far right side of the container (never in the middle or left)
  - You cannot add another photo selector without first selecting images for all of your current file selectors
  - You can submit variable amounts of images (after adding and deleting a bunch)
  - When you try to submit without adding at least 1 photo, you get an alert
  - Images always appear in the middle of the containers and scale in a way that makes sense

Notes:
- There are a lot of weird edge cases that I found while testing myself, which is why it took me so long to create this. Please be thorough in your testing. I wouldn't be surprised if you find something I overlooked. Thank you!!