### PR TITLE
altered schema for max-length

### DIFF
--- a/slug_trade/slug_trade_app/models.py
+++ b/slug_trade/slug_trade_app/models.py
@@ -70,7 +70,7 @@ class Item(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=80, blank=False)
     price = models.DecimalField(max_digits=9, decimal_places=2, blank=False)
-    category = models.CharField(max_length=1,
+    category = models.CharField(max_length=8,
                                 default="O",
                                 choices=ITEM_CATEGORIES,
                                 blank=False)


### PR DESCRIPTION
Item field category is now initialized with the correct character length requirement (8) appears to have fixed bug.