### PR TITLE
Pagination rework

### DIFF
--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -66,7 +66,7 @@ def products(request):
                     print(type)
                     items_list = items_list.exclude(item__trade_options=type)
 
-        paginator = Paginator(items_list, 12) # Show 6 items per page
+        paginator = Paginator(items_list, 12) # Alter the second parameter to change number of items per page
         page = request.GET.get('page', 1)
 
         try:

--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -76,6 +76,8 @@ def products(request):
         except EmptyPage:
             items = paginator.page(paginator.num_pages)
 
+        print('page range: ' + str(items.paginator.num_pages))
+
         return render(request, 'slug_trade_app/products.html', {'items': items, 'categories': categories, 'selected_values': selected_values, 'types': types, 'selected_types': selected_types})
 
     else:

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1523,6 +1523,36 @@ margin-left: 10px;
 
 .pagination li {
   display: inline-block;
-  margin: 0 5px;
-  padding: 5px;
+  margin: 0 3px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 15px;
+  color: black;
+}
+
+.pagination .active {
+  border-radius: 5px;
+  background-color: #fff3ce;
+}
+
+.pagination .button {
+  border-radius: 5px;
+}
+
+.pagination .button:hover {
+  background-color: #fff3ce;
+  cursor: pointer;
+}
+
+.pagination a {
+  text-decoration: none;
+  color: black;
+}
+
+.pagination li:hover {
+  border-radius: 5px;
+  background-color: #fff3ce;
+  cursor: pointer;
 }

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -8,6 +8,23 @@ var editProfileFormTouched = function(firstName, lastName, bio, onOffCampus, pro
   )
 };
 
+// This is the function that manipulates the url when pagination controlls are clicked
+var changePage = function(pageNumber) {
+  var url = window.location.href;
+  if(url.search(/page=\d+/i) == -1) {
+    if(url.search(/\?/i) == -1) {
+      var newUrl = url + '?page='+ pageNumber;
+    } else {
+      var newUrl = url + '&page=' + pageNumber;
+    }
+    window.location.href = newUrl;
+  } else {
+    var newUrl = url.replace(/page=\d+/i, 'page='+pageNumber);
+    console.log(newUrl);
+    window.location.href = newUrl
+  }
+};
+
 // add closet items helper functions and variables
 
 var addClosetItemDefaultImage = 'https://image.freepik.com/free-icon/question-mark-in-a-circle-outline_318-53407.jpg';
@@ -100,22 +117,6 @@ var shuffle = function() {
     }
   }
 }
-
-var changePage = function(pageNumber) {
-  var url = window.location.href;
-  if(url.search(/page=\d+/i) == -1) {
-    if(url.search(/\?/i) == -1) {
-      var newUrl = url + '?page='+ pageNumber;
-    } else {
-      var newUrl = url + '&page=' + pageNumber;
-    }
-    window.location.href = newUrl;
-  } else {
-    var newUrl = url.replace(/page=\d+/i, 'page='+pageNumber);
-    console.log(newUrl);
-    window.location.href = newUrl
-  }
-};
 
 $(document).ready(function() {
   // show drop links on hover

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -101,6 +101,22 @@ var shuffle = function() {
   }
 }
 
+var changePage = function(pageNumber) {
+  var url = window.location.href;
+  if(url.search(/page=\d+/i) == -1) {
+    if(url.search(/\?/i) == -1) {
+      var newUrl = url + '?page='+ pageNumber;
+    } else {
+      var newUrl = url + '&page=' + pageNumber;
+    }
+    window.location.href = newUrl;
+  } else {
+    var newUrl = url.replace(/page=\d+/i, 'page='+pageNumber);
+    console.log(newUrl);
+    window.location.href = newUrl
+  }
+};
+
 $(document).ready(function() {
   // show drop links on hover
   $(".links-drop, .links-box-wrapper").hover(function(){

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -10,9 +10,9 @@ var changePage = function(pageNumber) {
     window.location.href = newUrl;
   } else {
     var newUrl = url.replace(/page=\d+/i, 'page='+pageNumber);
-    console.log(newUrl);
     window.location.href = newUrl
   }
+};
 
 var editProfileFormTouched = function(firstName, lastName, bio, onOffCampus, profilePicture) {
   return (

--- a/slug_trade/templates/slug_trade_app/products.html
+++ b/slug_trade/templates/slug_trade_app/products.html
@@ -123,31 +123,31 @@
     </div>
 
     {% if items.has_other_pages %}
-    <ul class="pagination">
-      {% if items.number|add:'-4' > 1 %}
-        <li class="button pagination-link"><a href="?page={{ items.number|add:'-5' }}">&laquo;</a></li>
-      {% endif %}
-
-      {% if items.has_previous %}
-        <li class="button pagination-link"><a href="?page={{ items.previous_page_number }}">&lsaquo;</a></li>
-      {% endif %}
-
-      {% for i in items.paginator.page_range %}
-        {% if items.number == i %}
-          <li class="active pagination-link"><span>{{ i }}</span></li>
-        {% elif i > items.number|add:'-5' and i < items.number|add:'5' %}
-          <li class="pagination-link"><a href="?page={{ i }}">{{ i }}</a></li>
+      <ul class="pagination">
+        {% if items.number|add:'-4' > 1 %}
+          <li class="button" onclick="changePage({{ items.number|add:'-5' }})">&laquo;</li>
         {% endif %}
-      {% endfor %}
 
-      {% if items.has_next %}
-        <li class="button pagination-link"><a href="?page={{ items.next_page_number }}">&rsaquo;</a></li>
-      {% endif %}
+        {% if items.has_previous %}
+          <li class="button" onclick="changePage({{ items.previous_page_number }})">&lsaquo;</li>
+        {% endif %}
 
-      {% if items.paginator.num_pages > items.number|add:'4' %}
-        <li class="button pagination-link"><a href="?page={{ items.number|add:'5' }}">&raquo;</a></li>
-      {% endif %}
-    </ul>
+        {% for i in items.paginator.page_range %}
+          {% if items.number == i %}
+            <li class="active"><span>{{ i }}</span></li>
+          {% elif i > items.number|add:'-5' and i < items.number|add:'5' %}
+            <li onclick="changePage({{ i }})">{{ i }}</li>
+          {% endif %}
+        {% endfor %}
+
+        {% if items.has_next %}
+          <li onclick="changePage({{ items.next_page_number }})">&rsaquo;</li>
+        {% endif %}
+
+        {% if items.paginator.num_pages > items.number|add:'4' %}
+          <li class="button" onclick="changePage({{ items.number|add:'5' }})">&raquo;</li>
+        {% endif %}
+      </ul>
     {% endif %}
   </div>
 </div>

--- a/slug_trade/templates/slug_trade_app/products.html
+++ b/slug_trade/templates/slug_trade_app/products.html
@@ -67,20 +67,30 @@
     <div class="pagination-title-wrapper">
       <div class="products-categories-title">Products</div>
       {% if items.has_other_pages %}
-      <ul class="pagination">
-        {% if items.has_previous %}
-        <li><a href="?page={{ items.previous_page_number }}">&laquo;</a></li>
-        {% else %}
-        <li class="disabled"><span>&laquo;</span></li>
-        {% endif %} {% for i in items.paginator.page_range %} {% if items.number == i %}
-        <li class="active"><span>{{ i }}</span></li>
-        {% else %}
-        <li><a href="?page={{ i }}">{{ i }}</a></li>
-        {% endif %} {% endfor %} {% if items.has_next %}
-        <li><a href="?page={{ items.next_page_number }}">&raquo;</a></li>
-        {% else %}
-        <li class="disabled"><span>&raquo;</span></li>
-        {% endif %}
+        <ul class="pagination">
+          {% if items.number|add:'-4' > 1 %}
+            <li class="button" onclick="changePage({{ items.number|add:'-5' }})">&laquo;</li>
+          {% endif %}
+
+          {% if items.has_previous %}
+            <li class="button" onclick="changePage({{ items.previous_page_number }})">&lsaquo;</li>
+          {% endif %}
+
+          {% for i in items.paginator.page_range %}
+            {% if items.number == i %}
+              <li class="active"><span>{{ i }}</span></li>
+            {% elif i > items.number|add:'-5' and i < items.number|add:'5' %}
+              <li onclick="changePage({{ i }})">{{ i }}</li>
+            {% endif %}
+          {% endfor %}
+
+          {% if items.has_next %}
+            <li onclick="changePage({{ items.next_page_number }})">&rsaquo;</li>
+          {% endif %}
+
+          {% if items.paginator.num_pages > items.number|add:'4' %}
+            <li class="button" onclick="changePage({{ items.number|add:'5' }})">&raquo;</li>
+          {% endif %}
       </ul>
       {% endif %}
     </div>
@@ -114,18 +124,28 @@
 
     {% if items.has_other_pages %}
     <ul class="pagination">
+      {% if items.number|add:'-4' > 1 %}
+        <li class="button pagination-link"><a href="?page={{ items.number|add:'-5' }}">&laquo;</a></li>
+      {% endif %}
+
       {% if items.has_previous %}
-      <li><a href="?page={{ items.previous_page_number }}">&laquo;</a></li>
-      {% else %}
-      <li class="disabled"><span>&laquo;</span></li>
-      {% endif %} {% for i in items.paginator.page_range %} {% if items.number == i %}
-      <li class="active"><span>{{ i }}</span></li>
-      {% else %}
-      <li><a href="?page={{ i }}">{{ i }}</a></li>
-      {% endif %} {% endfor %} {% if items.has_next %}
-      <li><a href="?page={{ items.next_page_number }}">&raquo;</a></li>
-      {% else %}
-      <li class="disabled"><span>&raquo;</span></li>
+        <li class="button pagination-link"><a href="?page={{ items.previous_page_number }}">&lsaquo;</a></li>
+      {% endif %}
+
+      {% for i in items.paginator.page_range %}
+        {% if items.number == i %}
+          <li class="active pagination-link"><span>{{ i }}</span></li>
+        {% elif i > items.number|add:'-5' and i < items.number|add:'5' %}
+          <li class="pagination-link"><a href="?page={{ i }}">{{ i }}</a></li>
+        {% endif %}
+      {% endfor %}
+
+      {% if items.has_next %}
+        <li class="button pagination-link"><a href="?page={{ items.next_page_number }}">&rsaquo;</a></li>
+      {% endif %}
+
+      {% if items.paginator.num_pages > items.number|add:'4' %}
+        <li class="button pagination-link"><a href="?page={{ items.number|add:'5' }}">&raquo;</a></li>
       {% endif %}
     </ul>
     {% endif %}


### PR DESCRIPTION
New functionality:
- Pagination controls are more styled
- Pagination controls show a maximum of 9 pages at once
- Added << and >> buttons to navigate forward or backward 5 pages
- Fixed a bug where changing pages would get rid of applied filters

How to test:
- go to /products
- Make sure the pagination controls look good
- Change pages by clicking on the number and the <, > buttons
- Go into views.py and alter line 69. Change the second parameter of the function from 12 to 1. This will allow you to see what the pagination controls look like when there are more than 2 pages to display
- Make sure that the << and >> buttons work (they should move backward/forward 5 pages
- Change the 1 back to a 12 in views.py when you're finished testing