### PR TITLE
removed csrf token from the products filtering form

### DIFF
--- a/slug_trade/templates/slug_trade_app/products.html
+++ b/slug_trade/templates/slug_trade_app/products.html
@@ -11,7 +11,6 @@
 
 <div class="products-wrapper">
   <form method="get" id="products-form">
-    {% csrf_token %}
     <div class="products-categories-wrapper">
 
       <div class="products-categories-title">Filters</div>


### PR DESCRIPTION
Change:
- Removed an unnecessary csrf token from the filtering form

How to test:
- Go to /products and filter by anything, then make sure that you don't see a csrfmiddlewaretoken parameter in the url