### PR TITLE
bugfix: empty products page

### DIFF
--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -60,12 +60,11 @@ def products(request):
                     for value in values:
                         selected_types.append(value)
 
-            print(selected_types)
             for type in type_values:
                 if type not in selected_types:
-                    print(type)
                     items_list = items_list.exclude(item__trade_options=type)
 
+        item_count = items_list.count()
         paginator = Paginator(items_list, 12) # Alter the second parameter to change number of items per page
         page = request.GET.get('page', 1)
 
@@ -76,7 +75,7 @@ def products(request):
         except EmptyPage:
             items = paginator.page(paginator.num_pages)
 
-        return render(request, 'slug_trade_app/products.html', {'items': items, 'categories': categories, 'selected_values': selected_values, 'types': types, 'selected_types': selected_types})
+        return render(request, 'slug_trade_app/products.html', {'items': items, 'categories': categories, 'selected_values': selected_values, 'types': types, 'selected_types': selected_types, 'item_count': item_count})
 
     else:
         return render(request, 'slug_trade_app/not_authenticated.html')

--- a/slug_trade/templates/slug_trade_app/products.html
+++ b/slug_trade/templates/slug_trade_app/products.html
@@ -95,6 +95,9 @@
     </div>
 
     <div class="products-list-container">
+      {% if item_count == 0 %}
+        <h4>Nothing to see here!</h4>
+      {% endif %}
       {% for item in items %}
       <div class="products-item-wrapper">
         <div class="item-image-wrapper">


### PR DESCRIPTION
Bug:
- The products page was very empty when there were no query results

Fix:
- I added a message when there are no items to show

How to test:
- Filter by "Cash with items on top" and "Electronics". Make sure you see the message.
- Make sure you don't see the message when there are items to show