### PR TITLE
Item text rework

### DIFF
--- a/slug_trade/slug_trade_app/models.py
+++ b/slug_trade/slug_trade_app/models.py
@@ -34,7 +34,7 @@ CAMPUS_STATUS = (
 TRADE_OPTIONS = (
     ('0','Cash Only'),
     ('1','Cash and Items'),
-    ('2','Trade Only'),
+    ('2','Items Only'),
     ('3','Free')
 )
 

--- a/slug_trade/slug_trade_app/models.py
+++ b/slug_trade/slug_trade_app/models.py
@@ -33,8 +33,8 @@ CAMPUS_STATUS = (
 
 TRADE_OPTIONS = (
     ('0','Cash Only'),
-    ('1','Cash with items on top'),
-    ('2','Trade only'),
+    ('1','Cash and Items'),
+    ('2','Trade Only'),
     ('3','Free')
 )
 

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -346,6 +346,10 @@ input[type=submit]:hover {
   color: #777;
 }
 
+.item-type-price {
+  font-size: 14px;
+}
+
 .item-title {
   font-family: 'Archivo Black', sans-serif;
   font-size: 20px;

--- a/slug_trade/templates/slug_trade_app/products.html
+++ b/slug_trade/templates/slug_trade_app/products.html
@@ -111,8 +111,10 @@
 
           {% if item.item.get_trade_options_display == "Cash Only" %}
             <div class="item-type-price">${{item.item.price}}</div>
-          {% elif item.item.get_trade_options_display == "Trade only" %}
-            <div class="item-type-price">Make an offer</div>
+          {% elif item.item.get_trade_options_display == "Free" %}
+            <div class="item-type-price">$0.00</div>
+          {% else %}
+            <div class="item-type-price">Offers Welcome!</div>
           {% endif %}
 
         </div>

--- a/slug_trade/templates/slug_trade_app/profile.html
+++ b/slug_trade/templates/slug_trade_app/profile.html
@@ -139,21 +139,13 @@
 
             <div class="item-title">{{item.name|title}}</div>
             <div class="item-price-wrapper">
-
-              {% if item.get_trade_options_display == "Cash with items on top" %}
-                <div class="item-type-title">Trade Only</div>
-              {% else%}
-                <div class="item-type-price">{{item.get_trade_options_display}}</div>
-              {% endif %}
-
+              <div class="item-type-price">{{item.get_trade_options_display}}</div>
               {% if item.get_trade_options_display == "Cash Only" %}
                 <div class="item-type-price">${{item.price}}</div>
-              {% elif item.get_trade_options_display == "Trade Only" %}
-                <div class="item-type-price">Make an Offer</div>
-              {% elif item.get_trade_options_display == "Cash with items on top" %}
-                <div class="item-type-price">Make an Offer</div>
+              {% elif item.get_trade_options_display == "Free" %}
+                <div class="item-type-price">$0.00</div>
               {% else %}
-                <div class="item-type-price">Free</div>
+                <div class="item-type-price">Offers Welcome!</div>
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
Goal of this PR:
- Make the text underneath the item titles in the closet and the products page more sensible. Before, the purpose of the text was unclear. On your profile, many items said "Make an Offer", which implies that you can click on that text to make an offer on your own item. This PR aims to make the text explain what the trader wants for that item. For example, if they want cash only, it will show the price, and if they want to trade for only items, it will say Offers Welcome. 

Changes:
- I changed the names of the categories (in models.py) like such:
  - Cash with items on top --> Cash and Items
  - Trades only --> Items Only
  - Cash Only --> Cash Only (remained the same)
  - Free --> Free (remained the same)

How to test:
- Go to the profile page and make sure that the following properties hold:
  - Cash Only items show the price on the right side
  - Cash and Items / Items Only items say Offers Welcome! to the right side
  - Free items say $0.00 on the right side

- Go to the products page and ensure that the same 3 properties hold
- Ensure that filtering by trade options still works

Notes:
-  This started as me trying to fix the bug: Trade type is listed incorrectly in the closet, but in the process, I thought of better ways to convey our meaning behind that text, so I decided to do a full rework. The bug was also fixed in the process
