### PR TITLE
Trade categories fix

### DIFF
--- a/slug_trade/runserver.sh
+++ b/slug_trade/runserver.sh
@@ -1,1 +1,0 @@
-#!/usr/bin/env bash

--- a/slug_trade/runserver.sh
+++ b/slug_trade/runserver.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/slug_trade/slug_trade_app/management/commands/populate_db.py
+++ b/slug_trade/slug_trade_app/management/commands/populate_db.py
@@ -194,9 +194,8 @@ class Command(BaseCommand):
 
         TRADE_OPTIONS = (
             ('0', 'Cash Only'),
-            ('1', 'Cash with items on top'),
-            ('2', 'Trade only'),
-            ('3', 'Free')
+            ('1', 'Items Only'),
+            ('2', 'Free')
         )
         # create a random debug item for each image
         for picture in pictures_list:
@@ -207,7 +206,7 @@ class Command(BaseCommand):
                                price=random.random()*100,
                                category=self.categories[picture],
                                description=fake.text(),
-                               trade_options=random.choice(['0','2','3']))
+                               trade_options=random.choice(['0','1','2']))
             item.bid_counter = random.choice(range(100))
             item.save()
 

--- a/slug_trade/slug_trade_app/models.py
+++ b/slug_trade/slug_trade_app/models.py
@@ -33,9 +33,8 @@ CAMPUS_STATUS = (
 
 TRADE_OPTIONS = (
     ('0','Cash Only'),
-    ('1','Cash and Items'),
-    ('2','Items Only'),
-    ('3','Free')
+    ('1','Items Only'),
+    ('2','Free')
 )
 
 

--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -293,7 +293,7 @@ def trade_transaction(request, item_id=None):
         return redirect('/home')
     try:
         sale_item = Item.objects.get(id=item_id)
-        if sale_item.trade_options is not '2':
+        if sale_item.trade_options is not '1':
             # redirect them to item details that is appropriate for this specific item
             return HttpResponse(f"This is not a trade item"
                                 f" <a href='/item_details/{item_id}'>Go to this items details page</a>")
@@ -389,7 +389,7 @@ def free_transaction(request, item_id=None):
                                 f" <a href='/products'>go back to products page</a>")
           
         # check free
-        if free_item.trade_options is not '3':
+        if free_item.trade_options is not '2':
             # redirect them to item details that is appropriate for this specific item
             return HttpResponse(f"This is not a trade item <a href='/item_details/{item_id}'>Go to this items details page</a>")
     except Exception as e:


### PR DESCRIPTION
# Testing:
___
After renewing the database:
go to the route /products; there should be at least one item of each transaction type
items only, free, cash only

Attempting to manually access a route for a transaction with an item id that should not be processed by that route should not be allow, and an httpresponse will redirect the user to the home page

