### PR TITLE
Finished styling for offers page

### DIFF
--- a/slug_trade/slug_trade_app/forms.py
+++ b/slug_trade/slug_trade_app/forms.py
@@ -31,6 +31,8 @@ class CashTransactionForm(forms.ModelForm):
 
 
 class OfferCommentForm(forms.ModelForm):
+
+    comment = forms.CharField(widget=forms.Textarea(attrs={'class': 'offer-comment'}))
     class Meta:
         model = OfferComment
         fields = (

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -749,6 +749,11 @@ input[type=submit]:hover {
   height: auto;
 }
 
+.add-closet-wrapper-input {
+    padding: 20px;
+    font-size: 18px;
+}
+
 .profile-picture-wrapper img {
   height: 240px;
 }
@@ -1620,7 +1625,7 @@ item-details-image-row-wrapper{
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 100px 20px;
+  padding: 50px 20px;
 }
 
 .trasaction-body {
@@ -1629,7 +1634,7 @@ item-details-image-row-wrapper{
   justify-content: center;
   flex-direction: column;
   width: 100%;
-  max-width: 800px;
+  max-width: 650px;
 }
 
 .item-review-header-title {
@@ -1638,8 +1643,17 @@ item-details-image-row-wrapper{
   padding-bottom: 50px;
 }
 
+.item-review-subtitle {
+  font-family: 'Archivo Black', sans-serif;
+  font-size: 20px;
+  margin-top: 20px;
+  padding-bottom: 10px;
+}
+
 .item-review-wrapper {
   display: flex;
+  justify-content: space-between;
+  width: 100%;
   flex-direction: row;
 }
 
@@ -1647,12 +1661,17 @@ item-details-image-row-wrapper{
   display: flex;
   align-items: center;
   justify-content: space-between;
+  text-align: right;
+}
 
+.review-title span {
+  text-align: left;
 }
 
 .item-review-info-wrapper {
-  padding: 10px 20px;
+  padding: 10px 0;
   margin-left: 20px;
+  width: 100%;
 }
 
 .item-review-title span, .item-review-owner span, .item-review-price span {
@@ -1671,6 +1690,78 @@ item-details-image-row-wrapper{
   color: #F2CE60;
 }
 
+.item-review-form {
+  width: 100%;
+}
+
+#id_offer_amount {
+  border: 1px solid #d6d6d6;
+  border-radius: 5px;
+  padding: 20px 0 20px 25px;
+  font-size: 20px;
+  background-color: #fff;
+  width: 100%;
+  max-width: 628px;
+}
+
+.test {
+    position: relative;
+    background-color: #dedede;
+    display: inline;
+}
+
+.test:before {
+    content: '$';
+    position: absolute;
+    margin-top: -4px;
+    top: 0;
+    left: 12px;
+    z-index: 1;
+    font-size: 20px;
+}
+
+#id_comment {
+  border: 1px solid #d6d6d6;
+  border-radius: 5px;
+  padding: 20px 0 20px 25px;
+  font-size: 20px;
+  background-color: #fff;
+  width: 100%;
+  max-width: 628px;
+  margin-bottom: 40px;
+}
+
+.trade-offer-item-container {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(200px, 1fr));
+  grid-gap: 15px;
+}
+
+.trade-offer-item-container img {
+  width: 175px;
+  height: 175px;
+}
+
+.trade-offer-item-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #b1b1b1;
+  border-radius: 5px;
+  padding: 10px 0;
+}
+
+.trade-offer-item-wrapper label {
+  font-size: 18px;
+  font-weight: 900;
+  padding: 0 14px;
+  text-align: center;
+}
+
+.trade-offer-item-wrapper img {
+  margin: 10px 0;
+}
 
 /************ item details slider **********/
 .pgwSlider {
@@ -2040,65 +2131,6 @@ item-details-image-row-wrapper{
 
 }
 
-
-/****************** Transaction *******************/
-
-.transaction-wrapper {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 100px 20px;
-}
-
-.trasaction-body {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  flex-direction: column;
-  width: 100%;
-  max-width: 800px;
-}
-
-.item-review-header-title {
-  font-family: 'Archivo Black', sans-serif;
-  font-size: 40px;
-  padding-bottom: 50px;
-}
-
-.item-review-wrapper {
-  display: flex;
-  flex-direction: row;
-}
-
-.review-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-}
-
-.item-review-info-wrapper {
-  padding: 10px 20px;
-  margin-left: 20px;
-}
-
-.item-review-title span, .item-review-owner span, .item-review-price span {
-  font-family: 'Archivo Black', sans-serif;
-  font-size: 22px;
-  padding: 5px 0;
-  width: 175px;
-}
-
-.item-review-owner a {
-  text-decoration: none;
-  color: #333;
-}
-
-.item-review-owner a:hover {
-  color: #F2CE60;
-
-}
-
 /*********** products list *********/
 
 .products-wrapper {
@@ -2178,12 +2210,6 @@ item-details-image-row-wrapper{
   grid-gap: 15px;
 }
 
-/* <<<<<<< develop
-.showing-all {
-  font-size: 12px;
-}
-
-======= */
 .item-seller-wrapper {
   display: flex;
   justify-content: flex-start;
@@ -2467,5 +2493,4 @@ ul.pgwSlider.narrow.listOnTheLeft > li,
 .pgwSlider.narrow .ps-current .ps-next {
     padding: 15px 12px 15px 15px;
     top: 40%;
-
 }

--- a/slug_trade/templates/slug_trade_app/header-footer/navigation.html
+++ b/slug_trade/templates/slug_trade_app/header-footer/navigation.html
@@ -9,6 +9,7 @@
     </div>
 
     <div class="nav-links-wrapper">
+      <div class="nav-link"><a href="{% url 'slug_trade_app:products' %}">Products</a></div>
       <div class="nav-drop">
         {% if request.path != "/login/" %}
           {% if user.is_authenticated %}

--- a/slug_trade/templates/slug_trade_app/item_details.html
+++ b/slug_trade/templates/slug_trade_app/item_details.html
@@ -22,6 +22,7 @@
           <div class="item-details-price">Free</div>
         {% endif %}
       </div>
+      {{get_trade_type_display}}
       <a style="text-decoration: none;" href="/transaction/{{trade_type}}/{{item_id}}">
         <div class="item-details-snag-item-button">Snag Item</div>
       </a>

--- a/slug_trade/templates/slug_trade_app/transaction.html
+++ b/slug_trade/templates/slug_trade_app/transaction.html
@@ -14,7 +14,7 @@
 
         <div class="item-review-wrapper">
             <div class="item-review-image-wrapper">
-                <img src="{{ sale_item_image }}" width="200" alt="">
+                <img src="{{ sale_item_image }}" width="260" alt="">
             </div>
             <div class="item-review-info-wrapper">
                 <div class="item-review-title review-title"><span>Item &nbsp;</span>{{sale_item.name.title}}</div>
@@ -35,32 +35,37 @@
 
 
         {% if transaction_type == 'cash'%}
-        <form method="post">
+        <form class="item-review-form" method="post">
             {% csrf_token %}
-            <p>Cash Form here</p>
-            {{cash_transaction_form.as_p}}
-            <p>Comment Here</p>
-            {{offer_comment_form.as_p}}
+            <div class="item-review-subtitle">Offer amount</div>
+              <div class="test">
+                {{cash_transaction_form.offer_amount}}
+                {{cash_transaction_form.offer_amount.errors}}
+              </div>
+              <div class="item-review-subtitle">Comment</div>
+              {{offer_comment_form.comment}}
+              {{offer_comment_form.comment.errors}}
             <input id="signup-submit" type="submit" name="" value="Place Cash Offer">
         </form>
         {% endif %}
 
 
         {% if transaction_type == 'trade'%}
-        <form method="post">
+        <form class="item-review-form" method="post">
             {% csrf_token %}
-
-            <p>Comment Here</p>
-            {{offer_comment_form.as_p}}
-
-            {% for item in logged_in_users_items%}
-            <div>
-                <img src="{{item.image}}" width="120" alt="">
-            <input type="checkbox" name="selected-item" value="{{item.id}}">
-            <label>{{item.name}}</label>
+            <div class="item-review-subtitle">Trade Offer</div>
+            <div class="trade-offer-item-container">
+              {% for item in logged_in_users_items%}
+                  <div class="trade-offer-item-wrapper">
+                    <label>{{item.name|title}}</label>
+                    <img src="{{item.image}}" width="120" alt="">
+                    <input type="checkbox" name="selected-item" value="{{item.id}}">
+                  </div>
+              {% endfor %}
             </div>
-            <hr>
-            {% endfor %}
+            <div class="item-review-subtitle">Comment</div>
+            {{offer_comment_form.comment}}
+            {{offer_comment_form.comment.errors}}
             <input id="signup-submit" type="submit" name="" value="Place Trade">
         </form>
         {% endif %}
@@ -70,11 +75,10 @@
 
 
         {% if transaction_type == 'free'%}
-        <form method="post">
+        <form class="item-review-form" method="post">
             {% csrf_token %}
-            <p>Cash Form here</p>
             {{cash_transaction_form.as_p}}
-            <p>Comment Here</p>
+            <div class="item-review-subtitle">Comment</div>
             {{offer_comment_form.comment}}
             <input id="signup-submit" type="submit" name="" value="Grab it!">
         </form>
@@ -82,12 +86,6 @@
 
     </div>
 </div>
-
-
-<p>
-    Transaction Type <br>
-    {{transaction_type}}
-</p>
 
 
 {% endblock %}

--- a/slug_trade/templates/slug_trade_app/transaction.html
+++ b/slug_trade/templates/slug_trade_app/transaction.html
@@ -27,9 +27,8 @@
                 {% elif transaction_type == "trade" %}
                 <div class="item-review-price review-title"><span>Trade &nbsp;</span>Make an offer</div>
                 {% else %}
-                <div class="item-review-price review-title">Free</div>
+                <div class="item-review-price review-title"><span>Free &nbsp;</span>$0.00</div>
                 {% endif %}
-                <!--<div class="item-review-price review-title"><span>Trade</span></div>-->
             </div>
         </div>
 


### PR DESCRIPTION
**Overview**
- Worked out styling for offers page for cash items, trades, and free

**Test**
- The Functionality should still be working from the offer PR
- Go to offers page from a cash item. You should see a styled preview of the item the user is bidding on. A styled cash form with a dollar sign on the left. The dollar sign should not be touching the numbers. You should also see a styled text area for the comment and a submit button. 
- Go to the offers page from a trade item. You should see a styled preview of the item the user is bidding on. You should see a styled grid of items from your closet. You should see a styled text area for comment with a submit button
- Go to the offers page from a free item. You should see a styled preview of the item the user is bidding on. You should a styled text area for comment with a submit button. 
- Make sure the input fields do not bleed outside of the wrapper
