### PR TITLE
Bugfix: Snag Login

### DIFF
--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -54,7 +54,6 @@ def index(request):
     for value, name in TRADE_OPTIONS:
         types.append({ 'name': name, 'value': value })
 
-    print("At home")
     return render(request, 'slug_trade_app/index.html',{
         'items_and_images':items_and_images,
         'books_and_images': books_and_images,
@@ -177,7 +176,6 @@ def item_details(request, item_id=None):
     # render the details into a useful dictionary object
 
     if not item_id:
-
         return redirect('/products')
 
 
@@ -207,7 +205,7 @@ def cash_transaction(request, item_id=None):
 
     if not request.user.is_authenticated():
 
-        return redirect('/products')
+        return render(request, 'slug_trade_app/not_authenticated.html')
     # declare outside scope of try block
     sale_item = None
     try:
@@ -299,7 +297,7 @@ def trade_transaction(request, item_id=None):
     # ensure that no incorrect querys ever end up in this view
     if not request.user.is_authenticated():
 
-        return redirect('/home')
+        return render(request, 'slug_trade_app/not_authenticated.html')
     try:
         sale_item = Item.objects.get(id=item_id)
         if sale_item.trade_options is not '1':
@@ -382,7 +380,7 @@ def free_transaction(request, item_id=None):
     offer_comment_form = OfferCommentForm(request.POST)
 
     if not request.user.is_authenticated():
-        return redirect('/home')
+        return render(request, 'slug_trade_app/not_authenticated.html')
 
 
     free_item = None


### PR DESCRIPTION
New Functionality:
- When you are not logged in, and you click snag on an item, you are redirected to the not logged in page instead of home/products

How to test:
- Make sure you are not logged in and try to snag an item of type free, items only and cash only. Ensure that you are directed to the not logged in page for all item types
- Log back in and ensure that you can still get to the offer page from all trade types