### PR TITLE
Windows scripts

### DIFF
--- a/slug_trade/windows_renew_db.bat
+++ b/slug_trade/windows_renew_db.bat
@@ -2,3 +2,4 @@ CALL env\Scripts\activate.bat
 python manage.py makemigrations
 python manage.py migrate
 python manage.py populate_db
+CALL env\Scripts\deactivate.bat

--- a/slug_trade/windows_start.bat
+++ b/slug_trade/windows_start.bat
@@ -2,3 +2,4 @@ CALL env\Scripts\activate.bat
 python manage.py makemigrations
 python manage.py migrate
 python manage.py runserver
+CALL env\Scripts\deactivate.bat

--- a/slug_trade/windows_venv_setup.bat
+++ b/slug_trade/windows_venv_setup.bat
@@ -2,3 +2,4 @@ pip install virtualenv
 virtualenv env
 CALL env\Scripts\activate.bat
 pip install -r requirements.txt
+CALL env\Scripts\deactivate.bat


### PR DESCRIPTION
New Functionality:
- Added scripts for venv_setup, renew_db and start that will work on Windows

How to Test:

- Prerequisites:
  - You must be on a Windows machine
  - You must have python 3.4 or higher installed on the machine

- Run the following files in the windows command prompt, verifying that they work the same as the mac/linux scripts:
  
  - windows_venv_setup.bat
  - windows_renew_db.bat
  - windows_start.bat

- Notes:
  - You can run these files by either double clicking them in the Windows File Explorer, or navigating to slugtrade/slug_trade, then typing in the names of the files.
  - If you run the files by double clicking on them, the command prompt will close when the script is finished running
  - In order to make the venv_setup script more comprehensive, I added an instruction to pip install the virtualenv package in both windows_venv_setup.bat and venv_setup.sh