### PR TITLE
Bugfix: issue #124 (Item only trade comments are stored with the wrong owner)

### DIFF
--- a/slug_trade/slug_trade_app/views.py
+++ b/slug_trade/slug_trade_app/views.py
@@ -346,8 +346,8 @@ def trade_transaction(request, item_id=None):
             # create an offer comment and save it to the database
             new_comment = models.OfferComment(
                 item=sale_item,
-                item_owner=request.user,
-                comment_placed_by=sale_item.user,
+                item_owner=sale_item.user,
+                comment_placed_by=request.user,
                 comment=comment,
             )
             new_comment.save()


### PR DESCRIPTION
Bug:

- When an items only offer was placed, the comments would be stored in the wrong order within the database

How to test:

- Place an items only offer (with a comment)
- Check the Offer comments table in the admin app. Ensure that the comment has the correct users.