### PR TITLE
Bugfix: #121 (Products on other people's profiles are not clickable)

### DIFF
--- a/slug_trade/templates/slug_trade_app/profile.html
+++ b/slug_trade/templates/slug_trade_app/profile.html
@@ -119,7 +119,9 @@
             <div class="profile-item-wrapper">
 
             <div class="profile-item-image-wrapper">
-              <img src="{{images.0}}" width="240" alt="">
+              <a href="/item_details/{{item.id}}">
+                <img src="{{images.0}}" width="240" alt="">
+              </a>
             </div>
 
             {% if not public %}


### PR DESCRIPTION
Bug:

- Clicking on closet items in the profile page does nothing

How to test:

- Click on items in your closet. Ensure that you are taken to the item details page
- Click on items in other people's closets. Ensure that you are taken to the item details page

Note: 
- There is another bug out right now that allows users to snag their own items only items)