### PR TITLE
Profile update: image width, add item button, squished profile

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -54,8 +54,6 @@ footer {
   color: #F2CE60;
 }
 
-
-
 .pagination li {
   display: inline-block;
   padding: 10px;
@@ -102,7 +100,7 @@ footer {
 
 .nav-link-button:focus {
   outline:0;
-} 
+}
 
 .nav-drop {
   display: flex;
@@ -1170,6 +1168,7 @@ margin-left: 10px;
   background: #fff;
   padding: 100px 60px;
   margin: 140px 0;
+  padding-top: 0;
 }
 
 .closet-body {
@@ -1192,12 +1191,24 @@ margin-left: 10px;
   justify-content: center;
   border-radius: 200px;
   overflow: hidden;
-  width: 200px;
-  height: 200px;
+  width: 100%;
+  min-width: 200px;
 }
 
 .profile-info-image-wrapper img {
   border-radius: 200px;
+}
+
+@media screen and (max-width: 1215px) {
+  .profile-body {
+    padding-top: 0;
+  }
+  .profile-info-wrapper {
+    flex-direction: column;
+  }
+  .profile-info-image-wrapper {
+    padding-bottom: 40px;
+  }
 }
 
 .profile-info-content-wrapper {
@@ -1326,15 +1337,24 @@ margin-left: 10px;
   margin: 0;
 }
 
+.profile-closet-title-wrapper a {
+  text-decoration: none;
+}
+
 .profile-add-item-link {
   font-weight: 900;
   background-color: #fff;
   color: #333;
+  border: 1px solid #333;
+  border-radius: 5px;
+  padding: 15px;
   font-size: 14px;
 }
 
 .profile-add-item-link:hover {
-  color: #F2CE60;
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #333;
 }
 
 .profile-item-wrapper {
@@ -1350,6 +1370,10 @@ margin-left: 10px;
 }
 
 .profile-item-image-wrapper img {
+  width: 100%;
+}
+
+.profile-item-image-wrapper a {
   width: 100%;
 }
 

--- a/slug_trade/templates/slug_trade_app/profile.html
+++ b/slug_trade/templates/slug_trade_app/profile.html
@@ -18,7 +18,7 @@
 
       <div class="profile-info-image-wrapper">
         {% if user_to_view.userprofile.profile_picture %}
-          <img src="{{user_to_view.userprofile.profile_picture.url}}" height="200">
+          <img src="{{user_to_view.userprofile.profile_picture.url}}" width="200" height="200">
         {% endif %}
       </div>
 


### PR DESCRIPTION
**New functionality**
- Profile image no longer squishes 
- User image and data stacks on smaller screens
- Add item to closet button is restyled to match edit profile button
- Closet item images fit full width of container on larger screens

**Testing**

Button Style
- Button should have a dark gray border with a 5px radius, white background, dark gray text
- Clicking button should take you to add item page
- Hovering over the button should show white text and a dark gray background

Closet Item Style
- Expand your browser to be larger than your screen size. For any screen 13"+ the closet item's image should always be the same width of the parent wrapper/div (profile-item-image-wrapper)

Profile Image
- At all screen sizes the profile image should have proper proportions (1:1 ratio - should always be a squarish) 
- Shrink down your browser below 1215px width. The profile and image should stack vertically and the profile image should not be squished




