### PR TITLE
Bugfix: Issue #131 (Item images are squished on offer page)

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1874,7 +1874,7 @@ item-details-image-row-wrapper{
 }
 
 .trade-offer-item-wrapper input[type=checkbox] {
-  display: none;
+  visibility: hidden;
 }
 
 .trade-offer-item-wrapper label {
@@ -1885,6 +1885,7 @@ item-details-image-row-wrapper{
 }
 
 .trade-offer-item-wrapper img {
+  padding-top: 15px;
   margin: 10px 0;
   height: auto;
 }

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1851,7 +1851,7 @@ item-details-image-row-wrapper{
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   border: 1px solid #b1b1b1;
   border-radius: 5px;
   padding: 10px 0;

--- a/slug_trade/templates/slug_trade_app/transaction.html
+++ b/slug_trade/templates/slug_trade_app/transaction.html
@@ -58,9 +58,9 @@
                   <div class="trade-offer-item-wrapper">
                     <div class="trade-offer-item-title">
                         <label>{{item.name|title}}</label>
-                        <input type="checkbox" name="selected-item" value="{{item.id}}">
                     </div>
                     <img src="{{item.image}}" width="120" alt="">
+                    <input type="checkbox" name="selected-item" value="{{item.id}}">
                   </div>
               {% endfor %}
             </div>


### PR DESCRIPTION
Bug:
- On the offer page for items only items, the images are squished horizontally.

How to test:
- Go to to an items only offer page
- Check that images are no longer horizontally squished