### PR TITLE
Reworked the way you select closet items in an offer

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1746,8 +1746,8 @@ item-details-image-row-wrapper{
 .item-review-subtitle {
   font-family: 'Archivo Black', sans-serif;
   font-size: 20px;
-  margin-top: 20px;
-  padding-bottom: 10px;
+  margin-top: 30px;
+  padding-bottom: 20px;
 }
 
 .item-review-wrapper {
@@ -1850,6 +1850,16 @@ item-details-image-row-wrapper{
   border: 1px solid #b1b1b1;
   border-radius: 5px;
   padding: 10px 0;
+  -webkit-transition: all 400ms ease-in-out;
+  -moz-transition: all 400ms ease-in-out;
+  -o-transition: all 400ms ease-in-out;
+  -ms-transition: all 400ms ease-in-out;
+  transition: all 400ms ease-in-out;
+  cursor: pointer;
+}
+
+.trade-offer-item-wrapper input[type=checkbox] {
+  display: none;
 }
 
 .trade-offer-item-wrapper label {

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1850,12 +1850,16 @@ item-details-image-row-wrapper{
   border: 1px solid #b1b1b1;
   border-radius: 5px;
   padding: 10px 0;
-  -webkit-transition: all 400ms ease-in-out;
-  -moz-transition: all 400ms ease-in-out;
-  -o-transition: all 400ms ease-in-out;
-  -ms-transition: all 400ms ease-in-out;
-  transition: all 400ms ease-in-out;
+  -webkit-transition: all 250ms ease-in-out;
+  -moz-transition: all 250ms ease-in-out;
+  -o-transition: all 250ms ease-in-out;
+  -ms-transition: all 250ms ease-in-out;
+  transition: all 250ms ease-in-out;
   cursor: pointer;
+}
+
+.trade-offer-item-wrapper:hover {
+  background-color: #edeaea;
 }
 
 .trade-offer-item-wrapper input[type=checkbox] {

--- a/slug_trade/static/javascripts/main.js
+++ b/slug_trade/static/javascripts/main.js
@@ -509,4 +509,19 @@ $(document).ready(function() {
     $('#wishlist_item_description').focus();
   }
   // --------------- END OF WISHLIST FUNCTIONS ------------------------
+
+  // Handle clicking on closet item in item only offer page
+  $(function() {
+    $('.trade-offer-item-wrapper').click(function() {
+      var checkbox = $(this).find('[type=checkbox]');
+      if(checkbox.prop('checked')) {
+        checkbox.prop('checked', false);
+        $(this).css('background-color', 'inherit')
+      } else {
+        checkbox.prop('checked', true);
+        $(this).css('background-color', '#FFF3CE');
+      }
+    });
+  });
+
 });

--- a/slug_trade/templates/slug_trade_app/transaction.html
+++ b/slug_trade/templates/slug_trade_app/transaction.html
@@ -52,13 +52,15 @@
         {% if transaction_type == 'trade'%}
         <form class="item-review-form" method="post">
             {% csrf_token %}
-            <div class="item-review-subtitle">Trade Offer</div>
+            <div class="item-review-subtitle">Which of your items do you want to offer?</div>
             <div class="trade-offer-item-container">
               {% for item in logged_in_users_items%}
                   <div class="trade-offer-item-wrapper">
-                    <label>{{item.name|title}}</label>
+                    <div class="trade-offer-item-title">
+                        <label>{{item.name|title}}</label>
+                        <input type="checkbox" name="selected-item" value="{{item.id}}">
+                    </div>
                     <img src="{{item.image}}" width="120" alt="">
-                    <input type="checkbox" name="selected-item" value="{{item.id}}">
                   </div>
               {% endfor %}
             </div>


### PR DESCRIPTION
New Functionality:
- Instead of clicking a checkbox under each item that you want to offer (in an items only offer), you click the entire box.

How to Test:
- Make an offer on an items only item
- When you offer your closet items, make sure that you can do so by clicking anywhere on the box
- Any currently selected items will be highlighted in yellow
- Submit the offer, then check in the admin app that the correct closet items were offered 