### PR TITLE
Bugfix: Issue #146 (Footer misplaced on big screens)

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1,4 +1,9 @@
 
+.body-wrapper {
+  min-height: calc(94vh - 70px);
+  border: none;
+}
+
 .top-padding-100 {
   margin-top: 100px;
 }
@@ -172,6 +177,7 @@ footer {
   /* position:absolute;
   bottom:0;
   width:100%; */
+  height: 70px;
 }
 
 .footer-body {
@@ -179,12 +185,12 @@ footer {
   max-width: 700px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
   flex-direction: row;
+
 }
 
 .footer-link {
-  padding: 20px 35px;
   font-size: 12px;
 }
 

--- a/slug_trade/templates/slug_trade_app/add_closet_item.html
+++ b/slug_trade/templates/slug_trade_app/add_closet_item.html
@@ -293,8 +293,6 @@
     </div>
 </form>
 
-<hr>
-
 {% endblock %}
 
 {% block footer_block %}

--- a/slug_trade/templates/slug_trade_app/base.html
+++ b/slug_trade/templates/slug_trade_app/base.html
@@ -25,7 +25,9 @@
   {% block nav_block %}{% endblock %}
 
   <body>
-    {% block body_block %}{% endblock %}
+    <div class="body-wrapper">
+      {% block body_block %}{% endblock %}
+    </div>
   </body>
 
   <footer>


### PR DESCRIPTION
Bug:
- On large monitors, on pages that don't take up the entire page, the footer does not end up at the bottom

How to Test:
- Glance at all of the pages, making sure that the footer looks normal (and the rest of the page)