### PR TITLE
Added a shadow effect on the offer page items

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1858,7 +1858,7 @@ item-details-image-row-wrapper{
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  border: 1px solid #b1b1b1;
+  box-shadow: 1px 1px 1px 1px gray;
   border-radius: 5px;
   padding: 10px 0;
   -webkit-transition: all 250ms ease-in-out;


### PR DESCRIPTION
New Functionality:
- Added a shadow behind the closet items on the items only offer page

How to Test:
- Go to an items only offer
- Look at the closet items
- Ensure that they have a shadow effect behind the container
- Ensure that it looks good