### PR TITLE
Bugfix: Issue #158 (Dropdowns on add closet items are cut off)

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -830,8 +830,8 @@ input[type=submit]:hover {
 }
 
 .add-closet-wrapper-input {
-    padding: 20px;
     font-size: 18px;
+    font-family: inherit;
 }
 
 .profile-picture-wrapper img {


### PR DESCRIPTION
Bug:
- On windows / linux on firefox, the text in the dropdowns on the add closet item page was cut off

How to Test:
- Go to the add closet item page on a windows or linux machine using firefox
- Ensure that the dropdown menus look normal