### PR TITLE
Bugfix: Issue #160 (Textareas have courier font)

### DIFF
--- a/slug_trade/slug_trade_app/forms.py
+++ b/slug_trade/slug_trade_app/forms.py
@@ -32,7 +32,7 @@ class CashTransactionForm(forms.ModelForm):
 
 class OfferCommentForm(forms.ModelForm):
 
-    comment = forms.CharField(widget=forms.Textarea(attrs={'class': 'offer-comment'}))
+    comment = forms.CharField(widget=forms.Textarea(attrs={'class': 'input-textarea'}))
     class Meta:
         model = OfferComment
         fields = (
@@ -75,7 +75,7 @@ class ClosetItem(forms.ModelForm):
                                                   'class': 'add-closet-wrapper-input'
                                                   })
         self.fields['description'].widget.attrs.update({'required': True,
-                                                        'class': 'add-closet-wrapper-input'
+                                                        'class': 'input-textarea'
                                                         })
         self.fields['category'].widget.attrs.update({'class': 'add-closet-wrapper-input'})
         self.fields['condition'].widget.attrs.update({'class': 'add-closet-wrapper-input'})

--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -4,6 +4,12 @@
   border: none;
 }
 
+.input-textarea {
+  padding: 10px;
+  font-family: inherit;
+  font-size: inherit;
+}
+
 .top-padding-100 {
   margin-top: 100px;
 }


### PR DESCRIPTION
Bug:
- On the add closet item, edit closet item and make an offer pages, textareas have courier font

How to Test:
- Go to the add closet item page and make sure that the description field doesn't use courier font
- Go to the editcloset item page and make sure that the description field doesn't use courier font
- Go to the offer pages of all types (Cash, Items Only, Free) and make sure the comment field doesn't use courier font