### PR TITLE
Moved the title below the picture on the offer page items

### DIFF
--- a/slug_trade/static/css/styles.css
+++ b/slug_trade/static/css/styles.css
@@ -1860,13 +1860,13 @@ item-details-image-row-wrapper{
   justify-content: space-between;
   box-shadow: 1px 1px 1px 1px gray;
   border-radius: 5px;
-  padding: 10px 0;
   -webkit-transition: all 250ms ease-in-out;
   -moz-transition: all 250ms ease-in-out;
   -o-transition: all 250ms ease-in-out;
   -ms-transition: all 250ms ease-in-out;
   transition: all 250ms ease-in-out;
   cursor: pointer;
+  padding-top: 15px;
 }
 
 .trade-offer-item-wrapper:hover {
@@ -1885,8 +1885,6 @@ item-details-image-row-wrapper{
 }
 
 .trade-offer-item-wrapper img {
-  padding-top: 15px;
-  margin: 10px 0;
   height: auto;
 }
 

--- a/slug_trade/templates/slug_trade_app/transaction.html
+++ b/slug_trade/templates/slug_trade_app/transaction.html
@@ -56,10 +56,10 @@
             <div class="trade-offer-item-container">
               {% for item in logged_in_users_items%}
                   <div class="trade-offer-item-wrapper">
+                    <img src="{{item.image}}" width="120" alt="">
                     <div class="trade-offer-item-title">
                         <label>{{item.name|title}}</label>
                     </div>
-                    <img src="{{item.image}}" width="120" alt="">
                     <input type="checkbox" name="selected-item" value="{{item.id}}">
                     <p>{{item.description}}</p>
                   </div>


### PR DESCRIPTION
Change:
- On the Make an Offer page, I moved the title of each closet item below the picture and removed some un-needed padding

How to Test:
- Go to the offer page of an items only offer. Ensure that the closet items look good. 